### PR TITLE
reversed order of non-due items in widget list

### DIFF
--- a/src/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/src/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -358,7 +358,8 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 					null,
 					TaskContract.Instances.VISIBLE + ">0 and " + TaskContract.Instances.IS_CLOSED + "=0 AND (" + TaskContract.Instances.INSTANCE_START + "<="
 						+ System.currentTimeMillis() + " OR " + TaskContract.Instances.INSTANCE_START + " is null)", null,
-						TaskContract.Instances.INSTANCE_DUE + " is null, " + TaskContract.Instances.CREATED + " DESC");
+						TaskContract.Instances.INSTANCE_DUE + " is null, " + TaskContract.Instances.DEFAULT_SORT_ORDER + ", " +
+						TaskContract.Instances.CREATED + " DESC");
 
 				if (c != null)
 				{


### PR DESCRIPTION
The widget listed the task in the order of creation, ascending. These changes reverse this order, so the most recent tasks is on the top of the list.

I think this is more convenient, especially when the list is larget than the screen ;)
