### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/opentasks/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
+++ b/opentasks/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
@@ -799,6 +799,8 @@ public class DragLinearLayout extends LinearLayout
 					draggedItem.stopDetecting();
 				break;
 			}
+			default:
+			    break;
 		}
 
 		return false;
@@ -854,6 +856,8 @@ public class DragLinearLayout extends LinearLayout
 				}
 				return true;
 			}
+			default:
+			    break;
 		}
 		return false;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
@@ -203,6 +203,8 @@ public class EditTaskActivity extends ActionBarActivity
 			case android.R.id.home:
 				NavUtils.navigateUpFromSameTask(this);
 				return true;
+			default:
+			    break;
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/ViewTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/ViewTaskActivity.java
@@ -101,6 +101,8 @@ public class ViewTaskActivity extends AppCompatActivity implements ViewTaskFragm
 				upIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 				startActivity(upIntent);
 				finish();
+			default:
+			    break;
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/FlingDetector.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/FlingDetector.java
@@ -366,6 +366,8 @@ public class FlingDetector implements OnTouchListener, OnScrollListener
 					mFlingEnabled = false;
 				}
 				break;
+			default:
+			    break;
 		}
 		return handled;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck


Please let me know if you have any questions.

Sameer Misger