### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -382,7 +382,7 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 					+ TaskContract.Instances.INSTANCE_START + "<=" + System.currentTimeMillis() + " OR " + TaskContract.Instances.INSTANCE_START
 					+ " is null OR " + TaskContract.Instances.INSTANCE_START + " = " + TaskContract.Instances.INSTANCE_DUE + " )");
 
-				if (lists != null && lists.size() > 0)
+				if (lists != null && !lists.isEmpty())
 				{
 					selection.append(" AND ( ");
 

--- a/opentasks/src/main/java/org/dmfs/tasks/model/ContentSet.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/ContentSet.java
@@ -290,13 +290,13 @@ public final class ContentSet implements OnContentLoadedListener, Parcelable
 		keySet.retainAll(keys);
 
 		// if there is any element left in keySet both sets had at least one element in common
-		return keySet.size() > 0;
+		return !keySet.isEmpty();
 	}
 
 
 	public void ensureUpdates(Set<String> keys)
 	{
-		if (mBeforeContentValues == null || keys == null || keys.size() == 0)
+		if (mBeforeContentValues == null || keys == null || keys.isEmpty())
 		{
 			// nothing to do
 			return;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/adapters/ChecklistFieldAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/adapters/ChecklistFieldAdapter.java
@@ -109,7 +109,7 @@ public final class ChecklistFieldAdapter extends FieldAdapter<List<CheckListItem
 	public void set(ContentSet values, List<CheckListItem> value)
 	{
 		String oldDescription = DescriptionStringFieldAdapter.extractDescription(values.getAsString(mFieldName));
-		if (value != null && value.size() > 0)
+		if (value != null && !value.isEmpty())
 		{
 			StringBuilder sb = new StringBuilder(1024);
 			if (oldDescription != null)
@@ -134,7 +134,7 @@ public final class ChecklistFieldAdapter extends FieldAdapter<List<CheckListItem
 	public void set(ContentValues values, List<CheckListItem> value)
 	{
 		String oldDescription = DescriptionStringFieldAdapter.extractDescription(values.getAsString(mFieldName));
-		if (value != null && value.size() > 0)
+		if (value != null && !value.isEmpty())
 		{
 			StringBuilder sb = new StringBuilder(1024);
 			if (oldDescription != null)
@@ -224,7 +224,7 @@ public final class ChecklistFieldAdapter extends FieldAdapter<List<CheckListItem
 
 	private static void serializeCheckList(StringBuilder sb, List<CheckListItem> checklist)
 	{
-		if (checklist == null || checklist.size() == 0)
+		if (checklist == null || checklist.isEmpty())
 		{
 			return;
 		}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/contraints/ChecklistConstraint.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/contraints/ChecklistConstraint.java
@@ -46,7 +46,7 @@ public class ChecklistConstraint extends AbstractConstraint<List<CheckListItem>>
 	@Override
 	public List<CheckListItem> apply(ContentSet currentValues, List<CheckListItem> oldValue, List<CheckListItem> newValue)
 	{
-		if (oldValue != null && newValue != null && oldValue.size() > 0 && newValue.size() > 0 && !oldValue.equals(newValue))
+		if (oldValue != null && newValue != null && !oldValue.isEmpty() && !newValue.isEmpty() && !oldValue.equals(newValue))
 		{
 			int checked = 0;
 			for (CheckListItem item : newValue)

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/TasksListCursorAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/TasksListCursorAdapter.java
@@ -151,11 +151,11 @@ public class TasksListCursorAdapter extends android.support.v4.widget.CursorAdap
 
 				if (mListener != null)
 				{
-					if (oldSize == 0 && mSelectedLists.size() > 0)
+					if (oldSize == 0 && !mSelectedLists.isEmpty())
 					{
 						mListener.onSelectionEnabled();
 					}
-					if (oldSize > 0 && mSelectedLists.size() == 0)
+					if (oldSize > 0 && mSelectedLists.isEmpty())
 					{
 						mListener.onSelectionDisabled();
 					}

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/CheckListFieldViewLegacy.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/CheckListFieldViewLegacy.java
@@ -139,7 +139,7 @@ public class CheckListFieldViewLegacy extends AbstractFieldView implements OnChe
 	{
 		Context context = getContext();
 
-		if (list == null || list.size() == 0)
+		if (list == null || list.isEmpty())
 		{
 			setVisibility(GONE);
 			return;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 -  Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Sameer Misger