### PR TITLE
Fix typo in German translation

### DIFF
--- a/opentasks/src/main/res/values-de/strings.xml
+++ b/opentasks/src/main/res/values-de/strings.xml
@@ -221,7 +221,7 @@
     <string name="notification_action_delay_1h">+1 Stunde</string>
     <string name="notification_action_delay_1d">+1 Tag</string>
     <string name="notification_action_delay_toast">Fälligkeitsdatum aktualisiert</string>
-    <string name="notification_undo">Rückgänging</string>
+    <string name="notification_undo">Rückgängig</string>
     <string name="notification_action_unpin">Abheften</string>
     <string name="notification_task_pin_ticker">%1$s angeheftet</string>
 


### PR DESCRIPTION
This fixes a typo in the German translation of "undo", which is "Rückgängig" instead of "Rückgänging". It's a pretty annoying one as its shown everytime you mark a task as "done" from the status bar.