### PR TITLE
Widget: Don't show Tasks in the future with START==DUE

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -380,7 +380,7 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 				// build selection string
 				StringBuilder selection = new StringBuilder(TaskContract.Instances.VISIBLE + ">0 and " + TaskContract.Instances.IS_CLOSED + "=0 AND ("
 					+ TaskContract.Instances.INSTANCE_START + "<=" + System.currentTimeMillis() + " OR " + TaskContract.Instances.INSTANCE_START
-					+ " is null OR " + TaskContract.Instances.INSTANCE_START + " = " + TaskContract.Instances.INSTANCE_DUE + " )");
+					+ " is null)");
 
 				if (lists != null && lists.size() > 0)
 				{


### PR DESCRIPTION
Currently, the widget on the homescreen shows all visible and open tasks with one of the following conditions:
- Task has started (`TaskContract.Instances.INSTANCE_START + "<=" + System.currentTimeMillis()`)
- Task has no start date (`TaskContract.Instances.INSTANCE_START + " is null"`)
- Start date and due date are equal (`TaskContract.Instances.INSTANCE_START + " = " + TaskContract.Instances.INSTANCE_DUE`)

What's the motivation for the last one?

If I have a full-day Task for a day far away in the future, this task will be shown. However, the 5-minute Task which comes tomorrow will not be shown. In my view, it would be correct to hide both tasks and therefore the last condition (`TaskContract.Instances.INSTANCE_START + " = " + TaskContract.Instances.INSTANCE_DUE`) should be removed.

Have I missed something?