### PR TITLE
Widget: order by START date/time if DUE and PRIORITY are indistinguishable

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -407,8 +407,10 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 					null,
 					selection.toString(),
 					null,
-					TaskContract.Instances.INSTANCE_DUE + " is null, " + TaskContract.Instances.DEFAULT_SORT_ORDER + ", " + TaskContract.Instances.PRIORITY
-						+ " is null, " + TaskContract.Instances.PRIORITY + ", " + TaskContract.Instances.CREATED + " DESC");
+					Instances.INSTANCE_DUE + " is null, " + Instances.DEFAULT_SORT_ORDER + ", "
+							+ Instances.PRIORITY + " is null, " + Instances.PRIORITY + ", "
+							+ Instances.INSTANCE_START + " is null, " + Instances.INSTANCE_START_SORTING + ", "
+							+ Instances.CREATED + " DESC");
 
 				if (c != null)
 				{


### PR DESCRIPTION
Currently, the widget order is as follows:
1. by `DUE` (early due first, no due last)
2. by `PRIORITY` (high priority first, no priority last)
3. by `CREATED` (new tasks first)

In order to have a better control of tasks with the same (or no) `DUE` and `PRIORITY`, I propose to add a new condition `START` after `PRIORITY`:
1. by `DUE` (early due first, no due last)
2. by `PRIORITY` (high priority first, no priority last)
3. by `START` (early start first, no start last)
4. by `CREATED` (new tasks first)

Then, already started tasks are listed before tasks which haven't been started yet, and tasks which have been started a long time ago come before recently started tasks. This helps the user to keep the number of active tasks low in order to concentrate on finishing already started tasks. Furthermore, it allows to influence the order of tasks without `DUE` more fine-grained than using priorities.