### PR TITLE
Remove Flicker and Scroll-to-Top in Widget

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -134,7 +134,6 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 
 		public void reload()
 		{
-			mItems = null;
 			mExecutor.execute(mReloadTasks);
 		}
 


### PR DESCRIPTION
Sometimes, when the widget is reloaded (e.g. due to a background sync of tasks with DavDroid), the widget flickers and scrolls to the top of the list, which is very annoying. The cause of this is the reset of `mItems` to `null` at the begin of the `reload()` in combination with an external refresh of the widget. However, setting `mItems` to `null` is not required, since the background runnable sets the new value, when loading is finished.

Therefore, I removed this `null` reset which fixes the mentioned issue.