### PR TITLE
Improve task list selection when creating a new task from widget

### DIFF
--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
             </intent-filter>
         </activity>
 
-        <!-- EditTaskActivity listens for EDIT, INSERT and INDERT_OR_EDIT intents -->
+        <!-- EditTaskActivity listens for EDIT, INSERT and INSERT_OR_EDIT intents -->
         <activity
             android:name="org.dmfs.tasks.EditTaskActivity"
             android:label="@string/activity_add_task_title"

--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
@@ -47,7 +47,7 @@ public class EditTaskActivity extends ActionBarActivity
 
 	final static String EXTRA_DATA_BUNDLE = "org.dmfs.extra.BUNDLE";
 
-	final static String EXTRA_DATA_CONTENT_SET = "org.dmfs.DATA";
+	public final static String EXTRA_DATA_CONTENT_SET = "org.dmfs.DATA";
 
 	public final static String EXTRA_DATA_ACCOUNT_TYPE = "org.dmfs.ACCOUNT_TYPE";
 

--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
@@ -45,7 +45,7 @@ public class EditTaskActivity extends ActionBarActivity
 {
 	private static final String ACTION_NOTE_TO_SELF = "com.google.android.gm.action.AUTO_SEND";
 
-	final static String EXTRA_DATA_BUNDLE = "org.dmfs.extra.BUNDLE";
+	public final static String EXTRA_DATA_BUNDLE = "org.dmfs.extra.BUNDLE";
 
 	public final static String EXTRA_DATA_CONTENT_SET = "org.dmfs.DATA";
 

--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
@@ -36,6 +36,7 @@ import org.dmfs.tasks.model.Sources;
 import org.dmfs.tasks.model.TaskFieldAdapters;
 import org.dmfs.tasks.utils.ContentValueMapper;
 import org.dmfs.tasks.utils.OnModelLoadedListener;
+import org.dmfs.tasks.utils.RecentlyUsedLists;
 import org.dmfs.tasks.utils.TasksListCursorSpinnerAdapter;
 import org.dmfs.tasks.widget.ListenableScrollView;
 import org.dmfs.tasks.widget.ListenableScrollView.OnScrollListener;
@@ -770,6 +771,11 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
 				if (mValues.updatesAnyKey(RECURRENCE_VALUES))
 				{
 					mValues.ensureUpdates(RECURRENCE_VALUES);
+				}
+
+				if(mValues.isInsert()) {
+					// update recently used lists
+					RecentlyUsedLists.use(getContext(), mValues.getAsLong(Tasks.LIST_ID));
 				}
 
 				mTaskUri = mValues.persist(activity);

--- a/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
@@ -25,6 +25,7 @@ import org.dmfs.provider.tasks.TaskContract.TaskLists;
 import org.dmfs.provider.tasks.TaskContract.Tasks;
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.TaskFieldAdapters;
+import org.dmfs.tasks.utils.RecentlyUsedLists;
 import org.dmfs.tasks.utils.TasksListCursorSpinnerAdapter;
 
 import android.annotation.TargetApi;
@@ -362,6 +363,7 @@ public class QuickAddDialogFragment extends SupportDialogFragment
 	private void createTask()
 	{
 		ContentSet content = buildContentSet();
+		RecentlyUsedLists.use(getContext(), content.getAsLong(Tasks.LIST_ID)); // update recently used lists
 		content.persist(getActivity());
 	}
 

--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetProvider.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetProvider.java
@@ -30,6 +30,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.RemoteViews;
@@ -112,9 +113,12 @@ public class TaskListWidgetProvider extends AppWidgetProvider
 					// if there are multiple lists, then select the most recently used
 					preselectList = RecentlyUsedLists.getRecentFromList(context, writableLists);
 				}
+				Log.d(getClass().getSimpleName(), "create task with preselected list "+preselectList);
 				ContentSet contentSet = new ContentSet(Tasks.getContentUri(authority));
 				contentSet.put(Tasks.LIST_ID, preselectList);
-				editTaskIntent.putExtra(EditTaskActivity.EXTRA_DATA_CONTENT_SET, contentSet);
+				Bundle extraBundle = new Bundle();
+				extraBundle.putParcelable(EditTaskActivity.EXTRA_DATA_CONTENT_SET, contentSet);
+				editTaskIntent.putExtra(EditTaskActivity.EXTRA_DATA_BUNDLE, extraBundle);
 			}
 			context.startActivity(editTaskIntent);
 		}

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/RecentlyUsedLists.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/RecentlyUsedLists.java
@@ -21,7 +21,7 @@ public class RecentlyUsedLists {
      */
     public static List<Long> getList(Context context) {
         String strLists = PreferenceManager.getDefaultSharedPreferences(context).getString(PREFERENCE_KEY, "");
-        Log.d(RecentlyUsedLists.class.getSimpleName(), "getList:  "+strLists);
+        Log.v(RecentlyUsedLists.class.getSimpleName(), "getList:  "+strLists);
         List<Long> lists = new ArrayList<>();
         if(strLists.length()>0) {
             for (String lid : strLists.split(",")) {
@@ -38,7 +38,7 @@ public class RecentlyUsedLists {
      */
     private static void setList(Context context, List<Long> lists) {
         String strLists = TextUtils.join(",", lists);
-        Log.d(RecentlyUsedLists.class.getSimpleName(), "setList:  "+strLists);
+        Log.v(RecentlyUsedLists.class.getSimpleName(), "setList:  "+strLists);
         PreferenceManager.getDefaultSharedPreferences(context).edit().putString(PREFERENCE_KEY, strLists).commit();
     }
 

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/RecentlyUsedLists.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/RecentlyUsedLists.java
@@ -1,0 +1,72 @@
+package org.dmfs.tasks.utils;
+
+import android.content.Context;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class to record recently used lists in order to provide a pre-selection to the user.
+ */
+public class RecentlyUsedLists {
+    public static final String PREFERENCE_KEY = "RecentlyUsedLists";
+
+    /**
+     * Gets the lists of TaskLists ordered by recently use.
+     * @param context Context
+     * @return List of TaskLists where the most recently used list is on position 0.
+     */
+    public static List<Long> getList(Context context) {
+        String strLists = PreferenceManager.getDefaultSharedPreferences(context).getString(PREFERENCE_KEY, "");
+        Log.d(RecentlyUsedLists.class.getSimpleName(), "getList:  "+strLists);
+        List<Long> lists = new ArrayList<>();
+        if(strLists.length()>0) {
+            for (String lid : strLists.split(",")) {
+                lists.add(Long.parseLong(lid));
+            }
+        }
+        return lists;
+    }
+
+    /**
+     * Saves the ordered lists of TaskLists.
+     * @param context Context
+     * @param lists List of TaskLists where the most recently used list is on position 0.
+     */
+    private static void setList(Context context, List<Long> lists) {
+        String strLists = TextUtils.join(",", lists);
+        Log.d(RecentlyUsedLists.class.getSimpleName(), "setList:  "+strLists);
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putString(PREFERENCE_KEY, strLists).commit();
+    }
+
+    /**
+     * Searches for the best suitable TaskList in dependence of which is most recently used.
+     * @param context Context
+     * @param allowedLists List of TaskLists
+     * @return The most recently used TaskLists from <code>allowedLists</code>
+     */
+    public static Long getRecentFromList(Context context, List<Long> allowedLists) {
+        List<Long> recentlyLists = getList(context);
+        for (Long listId : recentlyLists) {
+            if(allowedLists.contains(listId)) {
+                return listId;
+            }
+        }
+        return allowedLists.get(0);
+    }
+
+    /**
+     * Mark a TaskLists as "used", which means that as new task was just created.
+     * @param context Context
+     * @param listId Id of the TaskList, where a task was just created.
+     */
+    public static void use(Context context, Long listId) {
+        List<Long> lists = getList(context);
+        lists.remove(listId); // does nothing, if "listId" is not in "lists"
+        lists.add(0, listId);
+        setList(context, lists);
+    }
+}


### PR DESCRIPTION
I'm using single widgets for every task list. In such a use case, it would be very useful, if a newly created task (using the `+` sign on the top-right corner of the widget) would use automatically the corresponding task list from the widget. Currently, the last selected list (from the previous edit) is used, which is often not desired.

This pull request therefore introduces a filter for the TaskList list in `EditTaskFragment`. Now, only such tasklists are shown, that are activated in the widget on which the `+` button was pressed.

What do you think about this solution? I see it as work in progress and looking forward for feedback.
### Tasks done
- [x] pre-select a suitable task list for new tasks with respect to the calling widget
- [x] only consider writable task lists
- [x] decide and implement a selection strategy for 2+ task lists
