### PR TITLE
Update checklist identification in combined description to use [] as …

### DIFF
--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -42,4 +42,5 @@ dependencies {
     compile('org.dmfs:opentasks-provider:1.1.8.1')
     compile 'com.google.android.apps.dashclock:dashclock-api:2.0.0'
     compile 'com.github.dmfs:color-picker:c3b3b52033dc0b33bd831e731ec6f74fb1e8a69a'
+    testCompile 'junit:junit:4.12'
 }

--- a/opentasks/src/test/java/org/dmfs/tasks/model/adapters/DescriptionExtractingTest.java
+++ b/opentasks/src/test/java/org/dmfs/tasks/model/adapters/DescriptionExtractingTest.java
@@ -1,0 +1,82 @@
+package org.dmfs.tasks.model.adapters;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static org.dmfs.tasks.model.adapters.DescriptionStringFieldAdapter.extractDescription;
+
+
+/**
+ * Test for the description extraction from the combined description-checklist string.
+ *
+ * @author Gabor Keszthelyi
+ */
+public class DescriptionExtractingTest
+{
+
+    @Test
+    public void testExtractDescription()
+    {
+        // No checklist
+        assertEquals("desc", extractDescription("desc"));
+        assertEquals("desc ", extractDescription("desc "));
+        assertEquals("desc\n", extractDescription("desc\n"));
+
+        assertEquals("des[c", extractDescription("des[c"));
+        assertEquals("desc]", extractDescription("desc]"));
+        assertEquals("[de]sc", extractDescription("[de]sc"));
+
+        assertEquals("desc [ ] no newline", extractDescription("desc [ ] no newline"));
+
+        // [ ]
+        assertEquals("", extractDescription("[ ]"));
+        assertEquals("", extractDescription("[ ][ ]"));
+        assertEquals("", extractDescription("[ ]\n[ ]"));
+        assertEquals("desc", extractDescription("desc\n[ ]"));
+        assertEquals("[desc", extractDescription("[desc\n[ ]"));
+        assertEquals("desc", extractDescription("desc\n[ ]hello"));
+        assertEquals("desc ", extractDescription("desc \n[ ]"));
+        assertEquals("desc", extractDescription("desc\n[ ]"));
+
+        // [x]
+        assertEquals("", extractDescription("[x]"));
+        assertEquals("", extractDescription("[x][x]"));
+        assertEquals("", extractDescription("[x]\n[x]"));
+        assertEquals("desc", extractDescription("desc\n[x]"));
+        assertEquals("[desc", extractDescription("[desc\n[x]"));
+        assertEquals("desc", extractDescription("desc\n[x]hello"));
+        assertEquals("desc ", extractDescription("desc \n[x]"));
+        assertEquals("desc", extractDescription("desc\n[x]"));
+
+        // [X]
+        assertEquals("", extractDescription("[X]"));
+        assertEquals("", extractDescription("[X]\n[X]"));
+        assertEquals("desc", extractDescription("desc\n[X]"));
+        assertEquals("[desc", extractDescription("[desc\n[X]"));
+        assertEquals("desc", extractDescription("desc\n[X]hello"));
+        assertEquals("desc ", extractDescription("desc \n[X]"));
+        assertEquals("desc", extractDescription("desc\n[X]"));
+
+        // []
+        assertEquals("", extractDescription("[]"));
+        assertEquals("", extractDescription("[][]"));
+        assertEquals("", extractDescription("[]\n[]"));
+        assertEquals("desc", extractDescription("desc\n[]"));
+        assertEquals("[desc", extractDescription("[desc\n[]"));
+        assertEquals("desc", extractDescription("desc\n[]hello"));
+        assertEquals("desc ", extractDescription("desc \n[]"));
+        assertEquals("desc", extractDescription("desc\n[]"));
+
+        assertEquals("desc", extractDescription("desc\n[ ] item1"));
+        assertEquals("desc", extractDescription("desc\n[x] item1\n[] item2"));
+    }
+
+
+    @Test
+    public void testExtractDescription_CR_removal()
+    {
+        assertEquals("desc", extractDescription("desc\r\n[x] item"));
+        assertEquals("desc ", extractDescription("desc \r\n[] item"));
+    }
+
+}


### PR DESCRIPTION
…well.

Created originally to fix #286, but that turned out to have been fixed already. ([comment](https://github.com/dmfs/opentasks/issues/286#issuecomment-254172441))
So this only adds the handling of [] the same as [ ] when extracting description from combined description-checklist, with tests and javadoc for the method.
