### PR TITLE
New constraints and defaults (forbid DUE=START)

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/groupings/BySearch.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/groupings/BySearch.java
@@ -22,7 +22,6 @@ import org.dmfs.provider.tasks.TaskContract.Tasks;
 import org.dmfs.tasks.R;
 import org.dmfs.tasks.groupings.cursorloaders.SearchHistoryCursorLoaderFactory;
 import org.dmfs.tasks.model.TaskFieldAdapters;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 import org.dmfs.tasks.utils.ExpandableChildDescriptor;
 import org.dmfs.tasks.utils.ExpandableGroupDescriptor;
 import org.dmfs.tasks.utils.ExpandableGroupDescriptorAdapter;
@@ -56,11 +55,6 @@ import android.widget.Toast;
  */
 public class BySearch extends AbstractGroupingFactory
 {
-	/**
-	 * An adapter to load the due date from the tasks projection.
-	 */
-	public final static TimeFieldAdapter TASK_DUE_ADAPTER = new TimeFieldAdapter(Tasks.DUE, Tasks.TZ, Tasks.IS_ALLDAY);
-
 	/**
 	 * A {@link ViewDescriptor} that knows how to present the tasks in the task list grouped by priority.
 	 */

--- a/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
@@ -120,12 +120,12 @@ public final class TaskFieldAdapters
 	/**
 	 * Adapter for the due date of a task.
 	 */
-	public final static FieldAdapter<Time> DUE = new CustomizedDefaultFieldAdapter<Time>(_DUE.addContraint(new After(_DTSTART)), new DefaultAfter(_DTSTART));
+	public final static FieldAdapter<Time> DUE = new CustomizedDefaultFieldAdapter<Time>(_DUE, new DefaultAfter(_DTSTART)).addContraint(new After(_DTSTART));
 
 	/**
 	 * Adapter for the start date of a task.
 	 */
-	public final static FieldAdapter<Time> DTSTART = new CustomizedDefaultFieldAdapter<Time>(_DTSTART.addContraint(new BeforeOrShiftTime(_DUE)), new DefaultBefore(_DUE));
+	public final static FieldAdapter<Time> DTSTART = new CustomizedDefaultFieldAdapter<Time>(_DTSTART, new DefaultBefore(DUE)).addContraint(new BeforeOrShiftTime(DUE));
 
 	/**
 	 * Adapter for the completed date of a task.

--- a/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
@@ -17,12 +17,16 @@
 
 package org.dmfs.tasks.model;
 
+import android.text.format.Time;
+
 import org.dmfs.provider.tasks.TaskContract;
 import org.dmfs.provider.tasks.TaskContract.Tasks;
 import org.dmfs.tasks.model.adapters.BooleanFieldAdapter;
 import org.dmfs.tasks.model.adapters.ChecklistFieldAdapter;
 import org.dmfs.tasks.model.adapters.ColorFieldAdapter;
+import org.dmfs.tasks.model.adapters.CustomizedDefaultFieldAdapter;
 import org.dmfs.tasks.model.adapters.DescriptionStringFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 import org.dmfs.tasks.model.adapters.FloatFieldAdapter;
 import org.dmfs.tasks.model.adapters.FormattedStringFieldAdapter;
 import org.dmfs.tasks.model.adapters.IntegerFieldAdapter;
@@ -31,9 +35,11 @@ import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 import org.dmfs.tasks.model.adapters.TimezoneFieldAdapter;
 import org.dmfs.tasks.model.adapters.UrlFieldAdapter;
 import org.dmfs.tasks.model.constraints.AdjustPercentComplete;
+import org.dmfs.tasks.model.constraints.After;
+import org.dmfs.tasks.model.constraints.BeforeOrShiftTime;
 import org.dmfs.tasks.model.constraints.ChecklistConstraint;
-import org.dmfs.tasks.model.constraints.NotBefore;
-import org.dmfs.tasks.model.constraints.ShiftIfAfter;
+import org.dmfs.tasks.model.defaults.DefaultAfter;
+import org.dmfs.tasks.model.defaults.DefaultBefore;
 
 
 /**
@@ -109,17 +115,17 @@ public final class TaskFieldAdapters
 	 * Private adapter for the start date of a task. We need this to reference DTSTART from DUE.
 	 */
 	private final static TimeFieldAdapter _DTSTART = new TimeFieldAdapter(Tasks.DTSTART, Tasks.TZ, Tasks.IS_ALLDAY);
+	private final static TimeFieldAdapter _DUE = new TimeFieldAdapter(Tasks.DUE, Tasks.TZ, Tasks.IS_ALLDAY);
 
 	/**
 	 * Adapter for the due date of a task.
 	 */
-	public final static TimeFieldAdapter DUE = (TimeFieldAdapter) new TimeFieldAdapter(Tasks.DUE, Tasks.TZ, Tasks.IS_ALLDAY).addContraint(new NotBefore(
-		_DTSTART));
+	public final static FieldAdapter<Time> DUE = new CustomizedDefaultFieldAdapter<Time>(_DUE.addContraint(new After(_DTSTART)), new DefaultAfter(_DTSTART));
 
 	/**
 	 * Adapter for the start date of a task.
 	 */
-	public final static TimeFieldAdapter DTSTART = (TimeFieldAdapter) _DTSTART.addContraint(new ShiftIfAfter(DUE));
+	public final static FieldAdapter<Time> DTSTART = new CustomizedDefaultFieldAdapter<Time>(_DTSTART.addContraint(new BeforeOrShiftTime(_DUE)), new DefaultBefore(_DUE));
 
 	/**
 	 * Adapter for the completed date of a task.

--- a/opentasks/src/main/java/org/dmfs/tasks/model/adapters/CustomizedDefaultFieldAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/adapters/CustomizedDefaultFieldAdapter.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dmfs.tasks.model.adapters;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import org.dmfs.tasks.model.ContentSet;
+import org.dmfs.tasks.model.OnContentChangeListener;
+import org.dmfs.tasks.model.defaults.Default;
+
+
+/**
+ * Enhances an existing {@link FieldAdapter} with a custom default value generator.
+ * 
+ * @param <Type> Type of the {@link FieldAdapter}
+ */
+public class CustomizedDefaultFieldAdapter<Type> extends FieldAdapter<Type> {
+
+    private final FieldAdapter<Type> mFieldAdapter;
+    private final Default<Type> mDefault;
+
+    /**
+     * Constructor for a new CustomizedDefaultFieldAdapter
+     * @param fieldAdapter FieldAdapter which forms the base for this Adapter.
+     * @param defaultGenerator Custom default value generator.
+     */
+    public CustomizedDefaultFieldAdapter(FieldAdapter<Type> fieldAdapter, Default<Type> defaultGenerator) {
+        if (fieldAdapter == null) {
+            throw new IllegalArgumentException("fieldAdapter must not be null");
+        }
+        if (defaultGenerator == null) {
+            throw new IllegalArgumentException("defaultGenerator must not be null");
+        }
+        this.mFieldAdapter = fieldAdapter;
+        this.mDefault = defaultGenerator;
+    }
+
+    @Override
+    public Type get(ContentSet values) {
+        return mFieldAdapter.get(values);
+    }
+
+    @Override
+    public Type get(Cursor cursor) {
+        return mFieldAdapter.get(cursor);
+    }
+
+    /**
+     * Get a default value for the {@link FieldAdapter} based on the {@link Default} instance.
+     *
+     * @param values    The {@link ContentSet}.
+     * @return	A default Value
+     */
+    @Override
+    public Type getDefault(ContentSet values) {
+        Type defaultValue = mFieldAdapter.getDefault(values);
+        return mDefault.getCustomDefault(values, defaultValue);
+    }
+
+    @Override
+    public void set(ContentSet values, Type value) {
+        mFieldAdapter.set(values, value);
+    }
+
+    @Override
+    public void set(ContentValues values, Type value) {
+        mFieldAdapter.set(values, value);
+    }
+
+    @Override
+    public void registerListener(ContentSet values, OnContentChangeListener listener, boolean initialNotification) {
+        mFieldAdapter.registerListener(values, listener, initialNotification);
+    }
+
+    @Override
+    public void unregisterListener(ContentSet values, OnContentChangeListener listener) {
+        mFieldAdapter.unregisterListener(values, listener);
+    }
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/adapters/TimeFieldAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/adapters/TimeFieldAdapter.java
@@ -156,13 +156,7 @@ public final class TimeFieldAdapter extends FieldAdapter<Time>
 		{
 			// make it an allday value
 			value.set(value.monthDay, value.month, value.year);
-		}
-		else
-		{
-			value.second = 0;
-			// round up to next quarter-hour
-			value.minute = ((value.minute + 14) / 15) * 15;
-			value.normalize(false);
+			value.timezone = Time.TIMEZONE_UTC; // all-day values are saved in UTC
 		}
 
 		return value;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
@@ -18,7 +18,7 @@ package org.dmfs.tasks.model.constraints;
 import android.text.format.Time;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 import org.dmfs.tasks.model.defaults.Default;
 import org.dmfs.tasks.model.defaults.DefaultAfter;
 
@@ -28,11 +28,11 @@ import org.dmfs.tasks.model.defaults.DefaultAfter;
  */
 public class After extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mReferenceAdapter;
+	private final FieldAdapter<Time> mReferenceAdapter;
 	private final Default<Time> mDefault;
 
 
-	public After(TimeFieldAdapter referenceAdapter)
+	public After(FieldAdapter<Time> referenceAdapter)
 	{
 		mReferenceAdapter = referenceAdapter;
 		mDefault = new DefaultAfter(referenceAdapter);

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.dmfs.tasks.model.constraints;
+
+import android.text.format.Time;
+
+import org.dmfs.tasks.model.ContentSet;
+import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.defaults.Default;
+import org.dmfs.tasks.model.defaults.DefaultAfter;
+
+
+/**
+ * Ensure a time is after a specific reference time. The new value will be set using {@link DefaultAfter} otherwise.
+ */
+public class After extends AbstractConstraint<Time>
+{
+	private final TimeFieldAdapter mReferenceAdapter;
+	private final Default<Time> mDefault;
+
+
+	public After(TimeFieldAdapter referenceAdapter)
+	{
+		mReferenceAdapter = referenceAdapter;
+		mDefault = new DefaultAfter(referenceAdapter);
+	}
+
+
+	@Override
+	public Time apply(ContentSet currentValues, Time oldValue, Time newValue)
+	{
+		Time reference = mReferenceAdapter.get(currentValues);
+		if (reference != null && newValue != null && !newValue.after(reference))
+		{
+			newValue.set(mDefault.getCustomDefault(currentValues, reference));
+		}
+		return newValue;
+	}
+
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
@@ -18,7 +18,7 @@ package org.dmfs.tasks.model.constraints;
 import android.text.format.Time;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 import org.dmfs.tasks.model.defaults.Default;
 import org.dmfs.tasks.model.defaults.DefaultAfter;
 
@@ -30,11 +30,11 @@ import org.dmfs.tasks.model.defaults.DefaultAfter;
  */
 public class BeforeOrShiftTime extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mReferenceAdapter;
+	private final FieldAdapter<Time> mReferenceAdapter;
 	private final Default<Time> mDefault;
 
 
-	public BeforeOrShiftTime(TimeFieldAdapter referenceAdapter)
+	public BeforeOrShiftTime(FieldAdapter<Time> referenceAdapter)
 	{
 		mReferenceAdapter = referenceAdapter;
 		mDefault = new DefaultAfter(null);

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.dmfs.tasks.model.constraints;
+
+import android.text.format.Time;
+
+import org.dmfs.tasks.model.ContentSet;
+import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.defaults.Default;
+import org.dmfs.tasks.model.defaults.DefaultAfter;
+
+
+/**
+ * Ensure a time is before a specific reference time.
+ * Otherwise, shift the reference time by the same amount that value has been shifted.
+ * If this still violated the constraint, then set the reference value to its default value.
+ */
+public class BeforeOrShiftTime extends AbstractConstraint<Time>
+{
+	private final TimeFieldAdapter mReferenceAdapter;
+	private final Default<Time> mDefault;
+
+
+	public BeforeOrShiftTime(TimeFieldAdapter referenceAdapter)
+	{
+		mReferenceAdapter = referenceAdapter;
+		mDefault = new DefaultAfter(null);
+	}
+
+
+	@Override
+	public Time apply(ContentSet currentValues, Time oldValue, Time newValue)
+	{
+		Time reference = mReferenceAdapter.get(currentValues);
+		if (reference != null && newValue != null)
+		{
+			if (oldValue != null && !newValue.before(reference))
+			{
+				// try to shift the reference value
+				long diff = newValue.toMillis(false) - oldValue.toMillis(false);
+				if (diff > 0)
+				{
+					boolean isAllDay = reference.allDay;
+					reference.set(reference.toMillis(false) + diff);
+
+					// ensure the event is still allday if is was allday before.
+					if (isAllDay)
+					{
+						reference.set(reference.monthDay, reference.month, reference.year);
+					}
+					mReferenceAdapter.set(currentValues, reference);
+				}
+			}
+			if (!newValue.before(reference))
+			{
+				// constraint is still violated, so set reference to its default value
+				reference.set(mDefault.getCustomDefault(currentValues, newValue));
+				mReferenceAdapter.set(currentValues, reference);
+			}
+		}
+		return newValue;
+	}
+
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotAfter.java
@@ -18,7 +18,7 @@
 package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 import android.text.format.Time;
 
@@ -30,10 +30,10 @@ import android.text.format.Time;
  */
 public class NotAfter extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mTimeAdapter;
+	private final FieldAdapter<Time> mTimeAdapter;
 
 
-	public NotAfter(TimeFieldAdapter adapter)
+	public NotAfter(FieldAdapter<Time> adapter)
 	{
 		mTimeAdapter = adapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotBefore.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotBefore.java
@@ -18,7 +18,7 @@
 package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 import android.text.format.Time;
 
@@ -30,10 +30,10 @@ import android.text.format.Time;
  */
 public class NotBefore extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mTimeAdapter;
+	private final FieldAdapter<Time> mTimeAdapter;
 
 
-	public NotBefore(TimeFieldAdapter adapter)
+	public NotBefore(FieldAdapter<Time> adapter)
 	{
 		mTimeAdapter = adapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftIfAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftIfAfter.java
@@ -18,7 +18,7 @@
 package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 import android.text.format.Time;
 
@@ -30,10 +30,10 @@ import android.text.format.Time;
  */
 public class ShiftIfAfter extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mTimeAdapter;
+	private final FieldAdapter<Time> mTimeAdapter;
 
 
-	public ShiftIfAfter(TimeFieldAdapter adapter)
+	public ShiftIfAfter(FieldAdapter<Time> adapter)
 	{
 		mTimeAdapter = adapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftTime.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftTime.java
@@ -18,7 +18,7 @@
 package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 import android.text.format.Time;
 
@@ -32,16 +32,16 @@ import android.text.format.Time;
  */
 public class ShiftTime extends AbstractConstraint<Time>
 {
-	private final TimeFieldAdapter mTimeAdapter;
+	private final FieldAdapter<Time> mTimeAdapter;
 
 
 	/**
 	 * Creates a new ShiftTime instance.
 	 * 
 	 * @param adapter
-	 *            A {@link TimeFieldAdapter} that knows how to load the value to shift.
+	 *            A {@link FieldAdapter<Time>} that knows how to load the value to shift.
 	 */
-	public ShiftTime(TimeFieldAdapter adapter)
+	public ShiftTime(FieldAdapter<Time> adapter)
 	{
 		mTimeAdapter = adapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/UpdateAllDay.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/UpdateAllDay.java
@@ -18,23 +18,23 @@
 package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 import android.text.format.Time;
 
 
 /**
- * Updates the value returned by a {@link TimeFieldAdapter} when the all-day flag changes. We need this if a task model doesn't support start or due dates. The
+ * Updates the value returned by a {@link FieldAdapter} of type Time when the all-day flag changes. We need this if a task model doesn't support start or due dates. The
  * sync adapter might still store those values, so we need to update them when the all-day flag changes.
  * 
  * @author Marten Gajda <marten@dmfs.org>
  */
 public class UpdateAllDay extends AbstractConstraint<Boolean>
 {
-	private final TimeFieldAdapter mTimeAdapter;
+	private final FieldAdapter<Time> mTimeAdapter;
 
 
-	public UpdateAllDay(TimeFieldAdapter adapter)
+	public UpdateAllDay(FieldAdapter<Time> adapter)
 	{
 		mTimeAdapter = adapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/defaults/Default.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/defaults/Default.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dmfs.tasks.model.defaults;
+
+import org.dmfs.tasks.model.ContentSet;
+
+/**
+ * Defines a default value of a specific type and a method that generates the respective value.
+ *
+ * @param <T> Type of the default value to be generated
+ */
+public interface Default<T>
+{
+	/**
+	 * Generates a default value of a specific type with respect to the current state of other values and a generic default.
+	 * @param currentValues     Other values in the {@link ContentSet} can be used in order to generate the default value.
+	 * @param genericDefault    A generic default value which can be used as fall-back if the {@link ContentSet} gives no clue.
+	 * @return Value of type <code>T</code>
+	 */
+	T getCustomDefault(ContentSet currentValues, T genericDefault);
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultAfter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dmfs.tasks.model.defaults;
+
+import android.text.format.Time;
+
+import org.dmfs.tasks.model.ContentSet;
+import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+
+/**
+ * Provides a value which defaults to NOW, but is always after a specific reference value.
+ * All-day values are set to the next day, date-time values are set to the next hour of the reference value.
+ */
+public class DefaultAfter implements Default<Time>
+{
+
+	private final TimeFieldAdapter mReferenceAdapter;
+
+
+	public DefaultAfter(TimeFieldAdapter referenceAdapter)
+	{
+		mReferenceAdapter = referenceAdapter;
+	}
+
+	@Override
+	public Time getCustomDefault(ContentSet currentValues, Time genericDefault)
+	{
+		Time reference = mReferenceAdapter!=null ? mReferenceAdapter.get(currentValues) : null;
+		boolean useReference = reference != null && !genericDefault.after(reference);
+		Time value = new Time(useReference ? reference : genericDefault);
+		if (value.allDay)
+		{
+			value.monthDay++;
+		}
+		else
+		{
+			value.second = 0;
+			value.minute = 0;
+			value.hour++;
+		}
+		value.normalize(false);
+		return value;
+	}
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultAfter.java
@@ -18,7 +18,7 @@ package org.dmfs.tasks.model.defaults;
 import android.text.format.Time;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 /**
  * Provides a value which defaults to NOW, but is always after a specific reference value.
@@ -27,10 +27,10 @@ import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 public class DefaultAfter implements Default<Time>
 {
 
-	private final TimeFieldAdapter mReferenceAdapter;
+	private final FieldAdapter<Time> mReferenceAdapter;
 
 
-	public DefaultAfter(TimeFieldAdapter referenceAdapter)
+	public DefaultAfter(FieldAdapter<Time> referenceAdapter)
 	{
 		mReferenceAdapter = referenceAdapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultBefore.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultBefore.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dmfs.tasks.model.defaults;
+
+import android.text.format.Time;
+
+import org.dmfs.tasks.model.ContentSet;
+import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+
+/**
+ * Provides a value which defaults to NOW, but is always before a specific reference value.
+ * All-day values are set to the previous day, date-time values are set to the start of the hour of the reference value.
+ */
+public class DefaultBefore implements Default<Time>
+{
+
+	private final TimeFieldAdapter mReferenceAdapter;
+
+
+	public DefaultBefore(TimeFieldAdapter referenceAdapter)
+	{
+		mReferenceAdapter = referenceAdapter;
+	}
+
+	@Override
+	public Time getCustomDefault(ContentSet currentValues, Time genericDefault)
+	{
+		Time reference = mReferenceAdapter!=null ? mReferenceAdapter.get(currentValues) : null;
+		boolean useReference = reference != null && !genericDefault.before(reference);
+		Time value = new Time(useReference ? reference : genericDefault);
+		if (value.allDay)
+		{
+			value.set(value.monthDay - (useReference ? 1 : 0), value.month, value.year);
+		}
+		else
+		{
+			value.minute--;
+			value.normalize(false);
+			value.second = 0;
+			value.minute = 0;
+		}
+		return value;
+	}
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultBefore.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/defaults/DefaultBefore.java
@@ -18,7 +18,7 @@ package org.dmfs.tasks.model.defaults;
 import android.text.format.Time;
 
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 
 /**
  * Provides a value which defaults to NOW, but is always before a specific reference value.
@@ -27,10 +27,10 @@ import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 public class DefaultBefore implements Default<Time>
 {
 
-	private final TimeFieldAdapter mReferenceAdapter;
+	private final FieldAdapter<Time> mReferenceAdapter;
 
 
-	public DefaultBefore(TimeFieldAdapter referenceAdapter)
+	public DefaultBefore(FieldAdapter<Time> referenceAdapter)
 	{
 		mReferenceAdapter = referenceAdapter;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/TimeFieldEditor.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/TimeFieldEditor.java
@@ -26,7 +26,7 @@ import java.util.TimeZone;
 import org.dmfs.tasks.R;
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.FieldDescriptor;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
+import org.dmfs.tasks.model.adapters.FieldAdapter;
 import org.dmfs.tasks.model.layout.LayoutOptions;
 
 import android.annotation.TargetApi;
@@ -66,7 +66,7 @@ public final class TimeFieldEditor extends AbstractFieldEditor implements OnDate
 	/**
 	 * The adapter to load the values from a {@link ContentSet}.
 	 */
-	private TimeFieldAdapter mAdapter;
+	private FieldAdapter<Time> mAdapter;
 
 	/**
 	 * The buttons to show the current date and time and to launch the date & time pickers.
@@ -159,7 +159,7 @@ public final class TimeFieldEditor extends AbstractFieldEditor implements OnDate
 	{
 		super.setFieldDescription(descriptor, layoutOptions);
 		Context context = getContext();
-		mAdapter = (TimeFieldAdapter) descriptor.getFieldAdapter();
+		mAdapter = (FieldAdapter<Time>) descriptor.getFieldAdapter();
 		mDefaultDateFormat = android.text.format.DateFormat.getDateFormat(context);
 		mDefaultTimeFormat = android.text.format.DateFormat.getTimeFormat(context);
 		mIs24hour = android.text.format.DateFormat.is24HourFormat(context);

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/TimeFieldView.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/TimeFieldView.java
@@ -25,7 +25,6 @@ import org.dmfs.tasks.R;
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.FieldDescriptor;
 import org.dmfs.tasks.model.adapters.FieldAdapter;
-import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 import org.dmfs.tasks.model.adapters.TimeZoneWrapper;
 import org.dmfs.tasks.model.layout.LayoutDescriptor;
 import org.dmfs.tasks.model.layout.LayoutOptions;
@@ -57,7 +56,7 @@ public final class TimeFieldView extends AbstractFieldView implements OnClickLis
 	/**
 	 * The {@link FieldAdapter} of the field for this view.
 	 */
-	private TimeFieldAdapter mAdapter;
+	private FieldAdapter<Time> mAdapter;
 
 	/**
 	 * The text view that shows the time in the local time zone.
@@ -133,7 +132,7 @@ public final class TimeFieldView extends AbstractFieldView implements OnClickLis
 	public void setFieldDescription(FieldDescriptor descriptor, LayoutOptions layoutOptions)
 	{
 		super.setFieldDescription(descriptor, layoutOptions);
-		mAdapter = (TimeFieldAdapter) descriptor.getFieldAdapter();
+		mAdapter = (FieldAdapter<Time>) descriptor.getFieldAdapter();
 		mText.setHint(descriptor.getHint());
 		findViewById(R.id.buttons).setVisibility(layoutOptions.getBoolean(LayoutDescriptor.OPTION_TIME_FIELD_SHOW_ADD_BUTTONS, false) ? VISIBLE : GONE);
 	}


### PR DESCRIPTION
- [x] `CustomizedDefaultFieldAdapter`: Introduce customizable default values (new interface `Default`) in order to provide different defaults for `DUE` (should be after `START`: new class `DefaultAfter`) and `START` (should be before `DUE`: new class `DefaultBefore`).
- [x] New constraint `After`: requires that a value is *after* another value (e.g. `DUE` must be after `START`); if constraint is violated, set value to the default (`DefaultAfter`); similar to the old `NotBefore`.
- [x] New constraint `BeforeOrShiftTime`: requires that a value is *before* another value (e.g. `START` must be before `DUE`); if constraint is violated, then the reference value (e.g. `DUE`) is shifted with respect to the duration of the task.

With the two new constraints, we prohibit `DUE=START` and therefore fix #262. The constraint `BeforeOrShiftTime` is a tradeoff between shifting always (cp. constraint `ShiftTime`) and shifting never (cp. constraint `NotAfter`); maybe this is sufficient in order to close #197.