### PR TITLE
fix spelling: contraint -> constraint

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/TaskFieldAdapters.java
@@ -30,10 +30,10 @@ import org.dmfs.tasks.model.adapters.StringFieldAdapter;
 import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
 import org.dmfs.tasks.model.adapters.TimezoneFieldAdapter;
 import org.dmfs.tasks.model.adapters.UrlFieldAdapter;
-import org.dmfs.tasks.model.contraints.AdjustPercentComplete;
-import org.dmfs.tasks.model.contraints.ChecklistConstraint;
-import org.dmfs.tasks.model.contraints.NotBefore;
-import org.dmfs.tasks.model.contraints.ShiftIfAfter;
+import org.dmfs.tasks.model.constraints.AdjustPercentComplete;
+import org.dmfs.tasks.model.constraints.ChecklistConstraint;
+import org.dmfs.tasks.model.constraints.NotBefore;
+import org.dmfs.tasks.model.constraints.ShiftIfAfter;
 
 
 /**

--- a/opentasks/src/main/java/org/dmfs/tasks/model/XmlModel.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/XmlModel.java
@@ -26,7 +26,7 @@ import org.dmfs.tasks.R;
 import org.dmfs.tasks.model.adapters.BooleanFieldAdapter;
 import org.dmfs.tasks.model.adapters.FieldAdapter;
 import org.dmfs.tasks.model.adapters.StringFieldAdapter;
-import org.dmfs.tasks.model.contraints.UpdateAllDay;
+import org.dmfs.tasks.model.constraints.UpdateAllDay;
 import org.dmfs.tasks.model.layout.LayoutDescriptor;
 import org.dmfs.xmlobjects.ElementDescriptor;
 import org.dmfs.xmlobjects.QualifiedName;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/adapters/FieldAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/adapters/FieldAdapter.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.OnContentChangeListener;
-import org.dmfs.tasks.model.contraints.AbstractConstraint;
+import org.dmfs.tasks.model.constraints.AbstractConstraint;
 
 import android.content.ContentValues;
 import android.database.Cursor;
@@ -58,7 +58,7 @@ public abstract class FieldAdapter<Type>
 	/**
 	 * Get the value from the given {@link Cursor}
 	 * 
-	 * @param values
+	 * @param cursor
 	 *            The {@link Cursor} that contain the value to return.
 	 * @return The value.
 	 */
@@ -139,16 +139,16 @@ public abstract class FieldAdapter<Type>
 	/**
 	 * Add a new constraint to this field adapter. Constraints are evaluated in the order they have been added.
 	 * 
-	 * @param contraint
+	 * @param constraint
 	 *            The new constraint.
 	 */
-	public final FieldAdapter<Type> addContraint(AbstractConstraint<Type> contraint)
+	public final FieldAdapter<Type> addContraint(AbstractConstraint<Type> constraint)
 	{
 		if (mConstraints == null)
 		{
 			mConstraints = new LinkedList<AbstractConstraint<Type>>();
 		}
-		mConstraints.add(contraint);
+		mConstraints.add(constraint);
 		return this;
 	}
 

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/AbstractConstraint.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/AbstractConstraint.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
 

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/AdjustPercentComplete.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/AdjustPercentComplete.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.provider.tasks.TaskContract.Tasks;
 import org.dmfs.tasks.model.ContentSet;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ChecklistConstraint.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ChecklistConstraint.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import java.util.List;
 

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotAfter.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
@@ -24,24 +24,16 @@ import android.text.format.Time;
 
 
 /**
- * Shift a reference time by the same amount that value has been shifted.
- * 
- * TODO: use Duration class to get the duration in days and shift without summer/winter time switches
+ * Ensure a time is not after a specific reference time. The new value will be set to the reference time otherwise.
  * 
  * @author Marten Gajda <marten@dmfs.org>
  */
-public class ShiftTime extends AbstractConstraint<Time>
+public class NotAfter extends AbstractConstraint<Time>
 {
 	private final TimeFieldAdapter mTimeAdapter;
 
 
-	/**
-	 * Creates a new ShiftTime instance.
-	 * 
-	 * @param adapter
-	 *            A {@link TimeFieldAdapter} that knows how to load the value to shift.
-	 */
-	public ShiftTime(TimeFieldAdapter adapter)
+	public NotAfter(TimeFieldAdapter adapter)
 	{
 		mTimeAdapter = adapter;
 	}
@@ -50,18 +42,13 @@ public class ShiftTime extends AbstractConstraint<Time>
 	@Override
 	public Time apply(ContentSet currentValues, Time oldValue, Time newValue)
 	{
-		Time timeToShift = mTimeAdapter.get(currentValues);
-		if (timeToShift != null && newValue != null && oldValue != null)
+		Time notAfterThisTime = mTimeAdapter.get(currentValues);
+		if (notAfterThisTime != null && newValue != null)
 		{
-			boolean isAllDay = timeToShift.allDay;
-			timeToShift.set(timeToShift.toMillis(false) + (newValue.toMillis(false) - oldValue.toMillis(false)));
-
-			// ensure the event is still allday if is was allday before.
-			if (isAllDay)
+			if (newValue.after(notAfterThisTime))
 			{
-				timeToShift.set(timeToShift.monthDay, timeToShift.month, timeToShift.year);
+				newValue.set(notAfterThisTime);
 			}
-			mTimeAdapter.set(currentValues, timeToShift);
 		}
 		return newValue;
 	}

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotBefore.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/NotBefore.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.adapters.TimeFieldAdapter;
@@ -24,16 +24,16 @@ import android.text.format.Time;
 
 
 /**
- * Ensure a time is not after a specific reference time. The new value will be set to the reference time otherwise.
+ * Ensure a time is not before a specific reference time. The new value will be set to the reference time otherwise.
  * 
  * @author Marten Gajda <marten@dmfs.org>
  */
-public class NotAfter extends AbstractConstraint<Time>
+public class NotBefore extends AbstractConstraint<Time>
 {
 	private final TimeFieldAdapter mTimeAdapter;
 
 
-	public NotAfter(TimeFieldAdapter adapter)
+	public NotBefore(TimeFieldAdapter adapter)
 	{
 		mTimeAdapter = adapter;
 	}
@@ -42,12 +42,12 @@ public class NotAfter extends AbstractConstraint<Time>
 	@Override
 	public Time apply(ContentSet currentValues, Time oldValue, Time newValue)
 	{
-		Time notAfterThisTime = mTimeAdapter.get(currentValues);
-		if (notAfterThisTime != null && newValue != null)
+		Time notBeforeThisTime = mTimeAdapter.get(currentValues);
+		if (notBeforeThisTime != null && newValue != null)
 		{
-			if (newValue.after(notAfterThisTime))
+			if (newValue.before(notBeforeThisTime))
 			{
-				newValue.set(notAfterThisTime);
+				newValue.set(notBeforeThisTime);
 			}
 		}
 		return newValue;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftIfAfter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/ShiftIfAfter.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.adapters.TimeFieldAdapter;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/UpdateAllDay.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/UpdateAllDay.java
@@ -15,7 +15,7 @@
  * 
  */
 
-package org.dmfs.tasks.model.contraints;
+package org.dmfs.tasks.model.constraints;
 
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.adapters.TimeFieldAdapter;


### PR DESCRIPTION
Refactoring of `org.dmfs.tasks.model.contraints` and `FieldAdapter.addContraint(AbstractConstraint<Type> contraint)` in order to correct misspelling of "constraint" (fixes #307).