### PR TITLE
Fix lint errors. #371

### DIFF
--- a/opentasks-provider/src/main/AndroidManifest.xml
+++ b/opentasks-provider/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
             android:permissionGroup="android.permission-group.PERSONAL_INFO"
             android:protectionLevel="dangerous"/>
 
+    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+
     <application>
         <provider
                 android:name="org.dmfs.provider.tasks.TaskProvider"

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
@@ -1345,7 +1345,7 @@ public final class TaskProvider extends SQLiteContentProvider implements OnAccou
         // On Android 2.3+ we just call the appropriate method
         try
         {
-            return packageManager.getProviderInfo(new ComponentName(context, providerClass), PackageManager.GET_PROVIDERS | PackageManager.GET_META_DATA);
+            return packageManager.getProviderInfo(new ComponentName(context, providerClass), PackageManager.GET_META_DATA);
         }
         catch (NameNotFoundException e)
         {

--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -35,10 +35,7 @@ android {
     }
 
     lintOptions {
-        // TODO: fix these
-        disable 'MissingTranslation'
-        disable 'ManifestResource'
-        disable 'ValidFragment'
+        disable 'MissingTranslation' // TODO
     }
 }
 

--- a/opentasks/src/main/java/org/dmfs/android/widgets/ColoredShapeCheckBox.java
+++ b/opentasks/src/main/java/org/dmfs/android/widgets/ColoredShapeCheckBox.java
@@ -24,8 +24,8 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
+import android.support.v7.widget.AppCompatCheckBox;
 import android.util.AttributeSet;
-import android.widget.CheckBox;
 
 import org.dmfs.tasks.R;
 
@@ -35,7 +35,7 @@ import org.dmfs.tasks.R;
  *
  * @author Marten Gajda <marten@dmfs.org>
  */
-public class ColoredShapeCheckBox extends CheckBox
+public class ColoredShapeCheckBox extends AppCompatCheckBox
 {
     /**
      * The initial color in case no other color is set. This color is transparent but the check mark will be dark.

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
@@ -149,10 +149,14 @@ public class TaskListFragment extends SupportFragment
         public boolean onChildClick(ExpandableListView parent, View v, int groupPosition, int childPosition, long id)
         {
             selectChildView(parent, groupPosition, childPosition, true);
-            if (mExpandableListView.getChoiceMode() == ExpandableListView.CHOICE_MODE_SINGLE)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
             {
-                mActivatedPositionGroup = groupPosition;
-                mActivatedPositionChild = childPosition;
+                if (mExpandableListView.getChoiceMode() == ExpandableListView.CHOICE_MODE_SINGLE)
+                {
+                    mActivatedPositionGroup = groupPosition;
+                    mActivatedPositionChild = childPosition;
+                }
             }
             /*
              * In contrast to a ListView an ExpandableListView does not set the activated item on it's own. So we have to do that here.
@@ -832,7 +836,10 @@ public class TaskListFragment extends SupportFragment
      */
     public void setActivateOnItemClick(boolean activateOnItemClick)
     {
-        mExpandableListView.setChoiceMode(activateOnItemClick ? ListView.CHOICE_MODE_SINGLE : ListView.CHOICE_MODE_NONE);
+        if (android.os.Build.VERSION.SDK_INT >= 11)
+        {
+            mExpandableListView.setChoiceMode(activateOnItemClick ? ListView.CHOICE_MODE_SINGLE : ListView.CHOICE_MODE_NONE);
+        }
     }
 
 
@@ -936,9 +943,12 @@ public class TaskListFragment extends SupportFragment
         {
             try
             {
-                mExpandableListView
-                        .setItemChecked(mExpandableListView.getFlatListPosition(ExpandableListView.getPackedPositionForChild(groupPosition, childPosition)),
-                                true);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+                {
+                    mExpandableListView
+                            .setItemChecked(mExpandableListView.getFlatListPosition(ExpandableListView.getPackedPositionForChild(groupPosition, childPosition)),
+                                    true);
+                }
             }
             catch (NullPointerException e)
             {

--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListSelectionFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListSelectionFragment.java
@@ -65,15 +65,9 @@ public class TaskListSelectionFragment extends ListFragment implements LoaderMan
     private Activity mActivity;
     private ListView mTaskList;
     private String mAuthority;
-    private onSelectionListener mListener;
+    private OnSelectionListener mListener;
     private TextView mButtonOk;
     private TextView mButtonCancel;
-
-
-    public TaskListSelectionFragment(onSelectionListener listener)
-    {
-        mListener = listener;
-    }
 
 
     @Override
@@ -81,6 +75,7 @@ public class TaskListSelectionFragment extends ListFragment implements LoaderMan
     {
         super.onAttach(activity);
         mActivity = activity;
+        mListener = (OnSelectionListener) activity;
         mAuthority = TaskContract.taskAuthority(activity);
     }
 
@@ -174,11 +169,11 @@ public class TaskListSelectionFragment extends ListFragment implements LoaderMan
     }
 
 
-    public interface onSelectionListener
+    public interface OnSelectionListener
     {
-        public void onSelection(ArrayList<Long> selectedLists);
+        void onSelection(ArrayList<Long> selectedLists);
 
-        public void onSelectionCancel();
+        void onSelectionCancel();
     }
 
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetSettingsActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetSettingsActivity.java
@@ -23,7 +23,7 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 
 import org.dmfs.tasks.R;
-import org.dmfs.tasks.homescreen.TaskListSelectionFragment.onSelectionListener;
+import org.dmfs.tasks.homescreen.TaskListSelectionFragment.OnSelectionListener;
 import org.dmfs.tasks.utils.WidgetConfigurationDatabaseHelper;
 
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ import java.util.ArrayList;
  *
  * @author Tobias Reinsch <tobias@dmfs.org>
  */
-public class TaskListWidgetSettingsActivity extends FragmentActivity implements onSelectionListener
+public class TaskListWidgetSettingsActivity extends FragmentActivity implements OnSelectionListener
 {
     private int mAppWidgetId;
     private Intent mResultIntent;
@@ -57,8 +57,9 @@ public class TaskListWidgetSettingsActivity extends FragmentActivity implements 
             setResult(RESULT_CANCELED, mResultIntent);
         }
 
-        TaskListSelectionFragment fragment = new TaskListSelectionFragment(this);
-        getSupportFragmentManager().beginTransaction().add(R.id.task_list_selection_container, fragment).commit();
+        getSupportFragmentManager().beginTransaction()
+                .add(R.id.task_list_selection_container, new TaskListSelectionFragment())
+                .commit();
     }
 
 

--- a/opentasks/src/main/java/org/dmfs/tasks/model/Sources.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/Sources.java
@@ -47,7 +47,7 @@ import java.util.Map;
 public final class Sources extends BroadcastReceiver implements OnAccountsUpdateListener
 {
 
-    public final static String TAG = "org.dmfs.tasks.model.Sources";
+    public final static String TAG = "tasks.model.Sources";
 
     /**
      * A Singleton instance in order to allow freeing it under memory pressure.

--- a/opentasks/src/main/java/org/dmfs/tasks/model/XmlModel.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/XmlModel.java
@@ -68,7 +68,7 @@ import java.util.Map.Entry;
  */
 public class XmlModel extends Model
 {
-    private final static String TAG = "org.dmfs.tasks.model.XmlModel";
+    private final static String TAG = "tasks.model.XmlModel";
 
     public final static String METADATA_TASKS = "org.dmfs.tasks.TASKS";
 

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationActionUtils.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationActionUtils.java
@@ -92,7 +92,7 @@ public class NotificationActionUtils
 
         // build notification
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context).setSmallIcon(R.drawable.ic_notification)
-                .setContentTitle(context.getString(R.string.notification_task_due_title, title)).setContentText(dueString);
+                .setContentTitle(title).setContentText(dueString);
 
         // color
         mBuilder.setColor(context.getResources().getColor(R.color.primary));
@@ -181,7 +181,7 @@ public class NotificationActionUtils
 
         // build notification
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context).setSmallIcon(R.drawable.ic_notification)
-                .setContentTitle(context.getString(R.string.notification_task_start_title, title)).setContentText(startString);
+                .setContentTitle(title).setContentText(startString);
 
         // color
         mBuilder.setColor(context.getResources().getColor(R.color.primary));

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationUpdaterService.java
@@ -67,7 +67,7 @@ import java.util.TimeZone;
  */
 public class NotificationUpdaterService extends Service
 {
-    private static final String TAG = "NotificationUpdaterService";
+    private static final String TAG = "NotificationUpdaterSe";
 
     /**
      * The duration in milliseconds of the heads up notification when pin tasks are due /start

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/TextFieldEditor.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/TextFieldEditor.java
@@ -73,7 +73,7 @@ public class TextFieldEditor extends AbstractFieldEditor implements OnFocusChang
     @Override
     protected void onFinishInflate()
     {
-        // super.onFinishInflate();
+        super.onFinishInflate();
         mText = (EditText) findViewById(android.R.id.text1);
         if (mText != null)
         {

--- a/opentasks/src/main/res/drawable/no_image.xml
+++ b/opentasks/src/main/res/drawable/no_image.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<color>
-
-
-</color>

--- a/opentasks/src/main/res/layout/activity_task_detail.xml
+++ b/opentasks/src/main/res/layout/activity_task_detail.xml
@@ -5,5 +5,4 @@
         android:layout_height="match_parent"
         android:background="@android:color/white"
         android:fitsSystemWindows="true"
-        tools:context=".TaskDetailActivity"
         tools:ignore="MergeRootFrame"/>

--- a/opentasks/src/main/res/layout/activity_task_editor.xml
+++ b/opentasks/src/main/res/layout/activity_task_editor.xml
@@ -4,5 +4,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/white"
-        tools:context=".AddTaskActivity"
         tools:ignore="MergeRootFrame"/>

--- a/opentasks/src/main/res/layout/activity_widget_configuration.xml
+++ b/opentasks/src/main/res/layout/activity_widget_configuration.xml
@@ -4,5 +4,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/white"
-        tools:context=".AddTaskActivity"
         tools:ignore="MergeRootFrame"/>

--- a/opentasks/src/main/res/menu/settings.xml
+++ b/opentasks/src/main/res/menu/settings.xml
@@ -1,9 +1,10 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
             android:id="@+id/action_settings"
             android:orderInCategory="100"
-            android:showAsAction="never"
+            app:showAsAction="never"
             android:title="@string/action_settings"/>
 
 </menu>

--- a/opentasks/src/main/res/menu/test_display.xml
+++ b/opentasks/src/main/res/menu/test_display.xml
@@ -1,9 +1,10 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
             android:id="@+id/action_settings"
             android:orderInCategory="100"
-            android:showAsAction="never"
+            app:showAsAction="never"
             android:title="@string/action_settings"/>
 
 </menu>

--- a/opentasks/src/main/res/values-cs/strings.xml
+++ b/opentasks/src/main/res/values-cs/strings.xml
@@ -28,6 +28,7 @@
 
     <plurals name="number_of_tasks">
         <item quantity="one">%d úkol</item>
+        <item quantity="few">%d úkoly</item>
         <item quantity="other">%d úkolů</item>
     </plurals>
 
@@ -85,7 +86,7 @@
     <string name="task_group_due_tomorrow">Zítra</string>
     <string name="task_group_due_within_7_days">Další dny</string>
     <string name="task_group_due_in_month">Splnit v %s</string>
-    <string name="task_group_due_in_year">Splnit v %s</string>
+    <string name="task_group_due_in_year">Splnit v %d</string>
     <string name="task_group_due_in_future">Někdy</string>
 
     <!-- Task list start group titles -->
@@ -208,8 +209,6 @@
     <string name="cd_due_date">ikona data ukončení úkolu</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Do kdy, %1s</string>
     <string name="notification_task_start_date">Od kdy, %1s</string>
     <string name="notification_task_due_today">Dodnes</string>

--- a/opentasks/src/main/res/values-de/strings.xml
+++ b/opentasks/src/main/res/values-de/strings.xml
@@ -82,7 +82,7 @@
     <string name="task_group_due_tomorrow">Morgen fällig</string>
     <string name="task_group_due_within_7_days">Bald fällig</string>
     <string name="task_group_due_in_month">Fällig im %s</string>
-    <string name="task_group_due_in_year">Fällig %s</string>
+    <string name="task_group_due_in_year">Fällig %d</string>
     <string name="task_group_due_in_future">Irgendwann</string>
 
     <!-- Task list start group titles -->
@@ -205,8 +205,6 @@
     <string name="cd_due_date">Symbol für das Fälligkeitsdatum der Aufgabe</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Aufgabe fällig, %1s</string>
     <string name="notification_task_start_date">Aufgabenbeginn, %1s</string>
     <string name="notification_task_due_today">Aufgabe heute fällig</string>

--- a/opentasks/src/main/res/values-es/strings.xml
+++ b/opentasks/src/main/res/values-es/strings.xml
@@ -85,7 +85,7 @@
     <string name="task_group_due_tomorrow">Vence mañana</string>
     <string name="task_group_due_within_7_days">Vence pronto</string>
     <string name="task_group_due_in_month">Vence en %s</string>
-    <string name="task_group_due_in_year">Vence en %s</string>
+    <string name="task_group_due_in_year">Vence en %d</string>
     <string name="task_group_due_in_future">Vence más tarde</string>
 
     <!-- Task list start group titles -->
@@ -211,8 +211,6 @@
     <string name="cd_due_date">icono para la fecha de vencimiento de la tarea</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Vencimiento de la tarea, %1s</string>
     <string name="notification_task_start_date">Comienzo de la tarea, %1s</string>
     <string name="notification_task_due_today">La tarea vence hoy</string>

--- a/opentasks/src/main/res/values-fr/strings.xml
+++ b/opentasks/src/main/res/values-fr/strings.xml
@@ -85,7 +85,7 @@
     <string name="task_group_due_tomorrow">À finir pour demain</string>
     <string name="task_group_due_within_7_days">À finir bientôt</string>
     <string name="task_group_due_in_month">À finir dans %s</string>
-    <string name="task_group_due_in_year">À finir dans %s</string>
+    <string name="task_group_due_in_year">À finir dans %d</string>
     <string name="task_group_due_in_future">À finir plus tard</string>
 
     <!-- Task list start group titles -->
@@ -208,8 +208,6 @@
     <string name="cd_due_date">icône pour la date de fin de la tâche</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Tâche à finir %1s</string>
     <string name="notification_task_start_date">Début de la tâche %1s</string>
     <string name="notification_task_due_today">Tâche à finir aujourd\'hui</string>

--- a/opentasks/src/main/res/values-hu/strings.xml
+++ b/opentasks/src/main/res/values-hu/strings.xml
@@ -84,8 +84,8 @@
     <string name="task_group_due_today">Ma</string>
     <string name="task_group_due_tomorrow">Holnap</string>
     <string name="task_group_due_within_7_days">Pár nap múlva</string>
-    <string name="task_group_due_in_month">%s múlva</string>
-    <string name="task_group_due_in_year">%s múlva</string>
+    <string name="task_group_due_in_month">%s</string>
+    <string name="task_group_due_in_year">%d</string>
     <string name="task_group_due_in_future">Valamikor</string>
 
     <!-- Task list start group titles -->
@@ -208,8 +208,6 @@
     <string name="cd_due_date">ikon a feladat határidejéhez</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Feladat határideje %1s</string>
     <string name="notification_task_start_date">Feladat kezdete %1s</string>
     <string name="notification_task_due_today">Feladat határideje ma</string>

--- a/opentasks/src/main/res/values-it/strings.xml
+++ b/opentasks/src/main/res/values-it/strings.xml
@@ -62,7 +62,7 @@
     <string name="task_group_due_tomorrow">Scadono domani</string>
     <string name="task_group_due_within_7_days">Scadono prossimamente</string>
     <string name="task_group_due_in_month">Scadono in %s</string>
-    <string name="task_group_due_in_year">Scadono nel %s</string>
+    <string name="task_group_due_in_year">Scadono nel %d</string>
     <string name="task_group_due_in_future">Scadono successivamente</string>
 
     <!-- Task editor labels -->

--- a/opentasks/src/main/res/values-ja/strings.xml
+++ b/opentasks/src/main/res/values-ja/strings.xml
@@ -85,7 +85,7 @@
     <string name="task_group_due_tomorrow">明日</string>
     <string name="task_group_due_within_7_days">以降</string>
     <string name="task_group_due_in_month">期限 %s</string>
-    <string name="task_group_due_in_year">期限 %s</string>
+    <string name="task_group_due_in_year">期限 %d</string>
     <string name="task_group_due_in_future">いつか</string>
 
     <!-- Task list start group titles -->
@@ -208,8 +208,6 @@
     <string name="cd_due_date">タスクの期日のアイコン</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">タスク期限, %1s</string>
     <string name="notification_task_start_date">タスク開始, %1s</string>
     <string name="notification_task_due_today">タスク期限が今日</string>

--- a/opentasks/src/main/res/values-nl/strings.xml
+++ b/opentasks/src/main/res/values-nl/strings.xml
@@ -83,7 +83,7 @@
     <string name="task_group_due_tomorrow">Morgen</string>
     <string name="task_group_due_within_7_days">Komende dagen</string>
     <string name="task_group_due_in_month">Einde in %s</string>
-    <string name="task_group_due_in_year">Einde in %s</string>
+    <string name="task_group_due_in_year">Einde in %d</string>
     <string name="task_group_due_in_future">Een keer</string>
 
     <!-- Task list start group titles -->
@@ -207,8 +207,6 @@
     <string name="cd_due_date">icoon voor einddatum van de taak</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">Taak einde</string>
-    <string name="notification_task_start_title">Taak start</string>
     <string name="notification_task_due_date">Taak te doen, %1s</string>
     <string name="notification_task_start_date">Taak begint, %1s</string>
     <string name="notification_task_due_today">Taak vandaag te doen</string>

--- a/opentasks/src/main/res/values-pl/strings.xml
+++ b/opentasks/src/main/res/values-pl/strings.xml
@@ -77,7 +77,7 @@
     <string name="task_group_due_tomorrow">Na jutro</string>
     <string name="task_group_due_within_7_days">Wkrótce</string>
     <string name="task_group_due_in_month">Na miesiąc %s</string>
-    <string name="task_group_due_in_year">W roku %s</string>
+    <string name="task_group_due_in_year">W roku %d</string>
     <string name="task_group_due_in_future">W przyszłości</string>
 
     <!-- Task list start group titles -->
@@ -200,8 +200,6 @@
     <string name="cd_due_date">ikonka terminu zakończenia zadania</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Zaplanowane %1s</string>
     <string name="notification_task_start_date">Rozpoczynające się %1s</string>
     <string name="notification_task_due_today">Zaplanowane na dziś</string>

--- a/opentasks/src/main/res/values-pt-rPT/strings.xml
+++ b/opentasks/src/main/res/values-pt-rPT/strings.xml
@@ -85,7 +85,7 @@
     <string name="task_group_due_tomorrow">Amanhã</string>
     <string name="task_group_due_within_7_days">Nos próximos dias</string>
     <string name="task_group_due_in_month">Termina em %s</string>
-    <string name="task_group_due_in_year">Termina em %s</string>
+    <string name="task_group_due_in_year">Termina em %d</string>
     <string name="task_group_due_in_future">Mais tarde</string>
 
     <!-- Task list start group titles -->
@@ -208,8 +208,6 @@
     <string name="cd_due_date">ícone para a data limite da tarefa</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Tarefa termina, %1s</string>
     <string name="notification_task_start_date">Tarefa inicia, %1s</string>
     <string name="notification_task_due_today">Tarefa termina hoje</string>

--- a/opentasks/src/main/res/values-pt-rbr/strings.xml
+++ b/opentasks/src/main/res/values-pt-rbr/strings.xml
@@ -75,7 +75,7 @@
     <string name="task_group_due_tomorrow">Amanhã</string>
     <string name="task_group_due_within_7_days">Próximos dias</string>
     <string name="task_group_due_in_month">Terminando em %s</string>
-    <string name="task_group_due_in_year">Terminando em %s</string>
+    <string name="task_group_due_in_year">Terminando em %d</string>
     <string name="task_group_due_in_future">Algum dia</string>
 
     <!-- Task list start group titles -->
@@ -198,8 +198,6 @@
     <string name="cd_due_date">ícone para o prazo da tarefa</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Terminar tarefa, %1s</string>
     <string name="notification_task_start_date">Começar tarefa, %1s</string>
     <string name="notification_task_due_today">Tarefa termina hoje</string>

--- a/opentasks/src/main/res/values-ru/strings.xml
+++ b/opentasks/src/main/res/values-ru/strings.xml
@@ -82,7 +82,7 @@
     <string name="task_group_due_tomorrow">Завтра</string>
     <string name="task_group_due_within_7_days">В течение недели</string>
     <string name="task_group_due_in_month">Срок в %s</string>
-    <string name="task_group_due_in_year">Срок в %s </string>
+    <string name="task_group_due_in_year">Срок в %d</string>
     <string name="task_group_due_in_future">В будущем</string>
 
     <!-- Task list start group titles -->
@@ -182,8 +182,6 @@
     <string name="cd_due_date">значок для срока выполнения задачи</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Срок выполнения задачи %1s</string>
     <string name="notification_task_start_date">Начало задачи %1s</string>
     <string name="notification_task_due_today">Срок выполнения задачи сегодня</string>

--- a/opentasks/src/main/res/values-sr/strings.xml
+++ b/opentasks/src/main/res/values-sr/strings.xml
@@ -76,7 +76,7 @@
     <string name="task_group_due_tomorrow">Сутра</string>
     <string name="task_group_due_within_7_days">Следећих дана</string>
     <string name="task_group_due_in_month">Истиче %s</string>
-    <string name="task_group_due_in_year">Истиче за %s</string>
+    <string name="task_group_due_in_year">Истиче за %d</string>
     <string name="task_group_due_in_future">Једног дана</string>
 
     <!-- Task list start group titles -->
@@ -199,8 +199,6 @@
     <string name="cd_due_date">икона за датум истека задатка</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Задатак истиче у %1s</string>
     <string name="notification_task_start_date">Задатак почиње у %1s</string>
     <string name="notification_task_due_today">Задатак истиче данас</string>

--- a/opentasks/src/main/res/values-uk/strings.xml
+++ b/opentasks/src/main/res/values-uk/strings.xml
@@ -78,7 +78,7 @@
     <string name="task_group_due_tomorrow">Завтра</string>
     <string name="task_group_due_within_7_days">На протязі тижня</string>
     <string name="task_group_due_in_month">Термін у %s</string>
-    <string name="task_group_due_in_year">Термін у %s </string>
+    <string name="task_group_due_in_year">Термін у %d</string>
     <string name="task_group_due_in_future">В майбутньому</string>
 
     <!-- Task list start group titles -->
@@ -201,8 +201,6 @@
     <string name="cd_due_date">значок для терміну виконання завдання</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Термін виконання завдання %1s</string>
     <string name="notification_task_start_date">Початок завдання %1s</string>
     <string name="notification_task_due_today">Термін виконання завдання сьогодні</string>

--- a/opentasks/src/main/res/values-v11/styles.xml
+++ b/opentasks/src/main/res/values-v11/styles.xml
@@ -71,13 +71,6 @@
         <item name="android:textAppearance">?android:attr/textAppearanceMedium</item>
     </style>
 
-    <style name="task_list_item_text"
-            parent="android:attr/textAppearanceMedium">
-        <item name="android:textColor"
-                tools:targetApi="14">@style/dark_text
-        </item>
-    </style>
-
     <style name="field_view_text_value"
             parent="dark_text">
         <item name="android:textAppearance">@android:style/TextAppearance.Medium</item>

--- a/opentasks/src/main/res/values/strings.xml
+++ b/opentasks/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="task_group_due_tomorrow">Tomorrow</string>
     <string name="task_group_due_within_7_days">Next days</string>
     <string name="task_group_due_in_month">Due in %s</string>
-    <string name="task_group_due_in_year">Due in %s</string>
+    <string name="task_group_due_in_year">Due in %d</string>
     <string name="task_group_due_in_future">Someday</string>
 
     <!-- Task list start group titles -->
@@ -209,8 +209,6 @@
     <string name="cd_due_date">icon for the due date of the task</string>
 
     <!-- Strings for notification -->
-    <string name="notification_task_due_title">%1s</string>
-    <string name="notification_task_start_title">%1s</string>
     <string name="notification_task_due_date">Task due, %1s</string>
     <string name="notification_task_start_date">Task start, %1s</string>
     <string name="notification_task_due_today">Task due today</string>


### PR DESCRIPTION
Notes:

---

I've removed these:
```
    <string name="notification_task_due_title">%1s</string>
    <string name="notification_task_start_title">%1s</string>
```
and the just the title directly for the notification, since this resource was the same in all langauges except in NL which was probably incorrect.

---

There was a missing, commented out super call in `TextFieldEditor` `onFinishInlfate()`, do you know if there was any reason for that or okay to put it in?

---

Added a CZ translation here ("few"):
```
    <plurals name="number_of_tasks">
        <item quantity="one">%d úkol</item>
        <item quantity="few">%d úkoly</item>
        <item quantity="other">%d úkolů</item>
    </plurals>
```
Lint said "few" is required for CZ, so I checked with Google Translate and it seemed to understand the plurals well, it was different for "1 task", "2 tasks", "200 tasks" with the first and last version corresponding to our existing translation, so I think that "few" should be good.

---

I've also corrected 2 translations in Hungarian.

---

In `TaskProvider`, I've removed the `PackageManager.GET_PROVIDERS` flag from here:
```
packageManager.getProviderInfo(new ComponentName(context, providerClass), PackageManager.GET_PROVIDERS | PackageManager.GET_META_DATA);
```
It is a not allowed flag there, I think it is supposed to be used with other methods.

---

Added this permission to `providers` module, since it was required by a method call in the module:
```
<uses-permission android:name="android.permission.GET_ACCOUNTS"/>
```