### PR TITLE
Apply workaround to fix framework bug of 'null' Resources while updat…

### DIFF
--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.dmfs.tasks"
-        xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="org.dmfs.tasks">
 
     <uses-permission android:name="org.dmfs.permission.READ_TASKS"/>
     <uses-permission android:name="org.dmfs.permission.WRITE_TASKS"/>
@@ -9,11 +9,12 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"></uses-permission>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name"
+            android:name=".TasksApplication"
             android:taskAffinity="org.dmfs.tasks.TaskListActivity"
             android:theme="@style/OpenTasksAppTheme">
 

--- a/opentasks/src/main/java/org/dmfs/tasks/TasksApplication.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TasksApplication.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.tasks;
+
+import android.app.Application;
+import android.os.Process;
+import android.util.Log;
+
+
+/**
+ * The {@link Application} class for the app.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class TasksApplication extends Application
+{
+
+    private static final String TAG = "TasksApplication";
+
+
+    @Override
+    public void onCreate()
+    {
+        super.onCreate();
+        checkAppReplacingState();
+    }
+
+
+    /*
+     * Fix for https://github.com/dmfs/opentasks/issues/383
+     * with workaround suggested at https://issuetracker.google.com/issues/36972466#comment14
+     */
+    private void checkAppReplacingState()
+    {
+        if (getResources() == null)
+        {
+            Log.w(TAG, "App is replacing and getResources() found to be null, killing process. (Workaround for framework bug 36972466");
+            Process.killProcess(Process.myPid());
+        }
+    }
+}


### PR DESCRIPTION
…ing app. #383 

---

I did one test after this:
Install 1.8.2 and then update latest from this branch while app is in background, nothing bad happened.

Probably there would be many more ways to test it or try to reproduce the original crash but based on the discussion in the Google bug tracker it's quite a peculiar problem, so I think it's not worth spending time on it on our side.
(https://issuetracker.google.com/issues/36972466)