### PR TITLE
Settings screen with Notifications checkbox. #279

### DIFF
--- a/.idea/dictionaries/dictionary.xml
+++ b/.idea/dictionaries/dictionary.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="dictionary">
+    <words>
+      <w>opentasks</w>
+    </words>
+  </dictionary>
+</component>

--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.dmfs.tasks"
-        xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="org.dmfs.tasks">
 
     <uses-permission android:name="org.dmfs.permission.READ_TASKS"/>
     <uses-permission android:name="org.dmfs.permission.WRITE_TASKS"/>
@@ -347,6 +347,11 @@
                         android:scheme="content"/>
             </intent-filter>
         </activity>
+        <!-- App Settings -->
+        <activity
+                android:name=".AppSettingsActivity"
+                android:theme="@style/AppTheme"
+                android:label="@string/title_activity_settings"/>
 
         <!-- Notification -->
         <receiver

--- a/opentasks/src/main/java/org/dmfs/tasks/AppSettingsActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/AppSettingsActivity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.tasks;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+import android.view.MenuItem;
+
+import org.dmfs.tasks.utils.AppCompatActivity;
+
+
+/**
+ * Activity for the general app settings screen.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
+public final class AppSettingsActivity extends AppCompatActivity
+{
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        getFragmentManager().beginTransaction()
+                .replace(android.R.id.content, new AppSettingsFragment())
+                .commit();
+
+        setupActionBar();
+    }
+
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        if (item.getItemId() == android.R.id.home)
+        {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    private void setupActionBar()
+    {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
+        {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+    }
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/AppSettingsFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/AppSettingsFragment.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.tasks;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
+
+
+/**
+ * Fragment for the general app settings.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
+public final class AppSettingsFragment extends PreferenceFragment
+{
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.app_preferences);
+    }
+}

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
@@ -61,7 +61,6 @@ import org.dmfs.tasks.groupings.ByProgress;
 import org.dmfs.tasks.groupings.BySearch;
 import org.dmfs.tasks.groupings.ByStartDate;
 import org.dmfs.tasks.model.ContentSet;
-import org.dmfs.tasks.notification.AlarmBroadcastReceiver;
 import org.dmfs.tasks.utils.AppCompatActivity;
 import org.dmfs.tasks.utils.ExpandableGroupDescriptor;
 import org.dmfs.tasks.utils.SearchHistoryHelper;
@@ -597,13 +596,6 @@ public class TaskListActivity extends AppCompatActivity implements TaskListFragm
             addItem.setVisible(false);
         }
 
-        // restore menu state
-        MenuItem item = menu.findItem(R.id.menu_alarms);
-        if (item != null)
-        {
-            item.setChecked(AlarmBroadcastReceiver.getAlarmPreference(this));
-        }
-
         // search
         setupSearch(menu);
 
@@ -626,12 +618,9 @@ public class TaskListActivity extends AppCompatActivity implements TaskListFragm
             startActivity(settingsIntent);
             return true;
         }
-        else if (item.getItemId() == R.id.menu_alarms)
+        else if (item.getItemId() == R.id.opentasks_menu_app_settings)
         {
-            // set and save state
-            boolean activatedAlarms = !item.isChecked();
-            item.setChecked(activatedAlarms);
-            AlarmBroadcastReceiver.setAlarmPreference(this, activatedAlarms);
+            startActivity(new Intent(this, AppSettingsActivity.class));
             return true;
         }
         else

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/AlarmBroadcastReceiver.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/AlarmBroadcastReceiver.java
@@ -22,7 +22,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.preference.PreferenceManager;
 
+import org.dmfs.tasks.R;
 import org.dmfs.tasks.contract.TaskContract;
 
 
@@ -34,10 +36,6 @@ import org.dmfs.tasks.contract.TaskContract;
 public class AlarmBroadcastReceiver extends BroadcastReceiver
 {
 
-    private static String PREFS_NAME = "alarm_preferences";
-    private static String PREF_ALARM_ACTIVATED = "preference_alarm_activated";
-
-
     /**
      * Is called on an incoming alarm broadcast. Creates a notifications for this alarm.
      */
@@ -47,7 +45,7 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver
         // continue if alarms where enabled
         if (intent.getAction().equals(TaskContract.ACTION_BROADCAST_TASK_STARTING))
         {
-            if (getAlarmPreference(context))
+            if (isNotificationEnabled(context))
             {
                 Uri taskUri = intent.getData();
 
@@ -72,7 +70,7 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver
         }
         else if (intent.getAction().equals(TaskContract.ACTION_BROADCAST_TASK_DUE))
         {
-            if (getAlarmPreference(context))
+            if (isNotificationEnabled(context))
             {
                 Uri taskUri = intent.getData();
 
@@ -100,20 +98,10 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver
     }
 
 
-    public static void setAlarmPreference(Context context, boolean value)
+    public boolean isNotificationEnabled(Context context)
     {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, 0);
-        SharedPreferences.Editor editor = settings.edit();
-        editor.putBoolean(PREF_ALARM_ACTIVATED, value);
-        editor.commit();
-
-    }
-
-
-    public static boolean getAlarmPreference(Context context)
-    {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, 0);
-        return settings.getBoolean(PREF_ALARM_ACTIVATED, true);
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+        return settings.getBoolean(context.getString(R.string.schedjoules_pref_notification_enabled), true);
 
     }
 }

--- a/opentasks/src/main/res/menu/task_list_activity_menu.xml
+++ b/opentasks/src/main/res/menu/task_list_activity_menu.xml
@@ -17,11 +17,12 @@
     <item
             android:id="@+id/menu_visible_list"
             android:title="@string/visible_task_lists"
-            app:showAsAction="never"></item>
+            app:showAsAction="never"/>
+
     <item
-            android:id="@+id/menu_alarms"
-            android:checkable="true"
-            android:title="@string/enable_alarms"
-            app:showAsAction="never"></item>
+            android:id="@+id/opentasks_menu_app_settings"
+            android:title="@string/title_activity_settings"
+            android:visible="@bool/postHoneycomb"
+            app:showAsAction="never"/>
 
 </menu>

--- a/opentasks/src/main/res/values/prefs.xml
+++ b/opentasks/src/main/res/values/prefs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="schedjoules_pref_notification_enabled"
+            translatable="false">schedjoules_pref_notification_enabled</string>
+
+</resources>

--- a/opentasks/src/main/res/xml/app_preferences.xml
+++ b/opentasks/src/main/res/xml/app_preferences.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <CheckBoxPreference
+            android:key="@string/schedjoules_pref_notification_enabled"
+            android:title="@string/enable_alarms"
+            android:defaultValue="true"/>
+</PreferenceScreen>


### PR DESCRIPTION
The base branch is a new `settings/master` for this pull request, since I've only added the existing Notifications switch to the new Settings screen here, and I suppose we wouldn't release it with at least 2 items there.

One question here is the order of items in the menu. I see the items are added from both `TaskListActivity` and `TaskListFragment`. Since they are always shown together could we maybe use just one of them?