### PR TITLE
Tests for TaskProvider #410

### DIFF
--- a/opentasks-provider/build.gradle
+++ b/opentasks-provider/build.gradle
@@ -21,11 +21,21 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    packagingOptions {
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+    }
 }
 
 dependencies {
     compile('org.dmfs:rfc5545-datetime:0.2.4')
     compile('org.dmfs:lib-recur:0.9.6')
     compile project(':opentasks-contract')
-    testCompile 'junit:junit:4.12'
+
+    androidTestCompile project(':opentaskspal')
+    androidTestCompile 'com.github.dmfs.contentpal:contenttestpal:' + CONTENTPAL_VERSION
+    androidTestCompile 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderTest.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks;
+
+import android.content.ContentProviderClient;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.os.Build;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.dmfs.android.contentpal.OperationsQueue;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.batches.MultiBatch;
+import org.dmfs.android.contentpal.batches.SingletonBatch;
+import org.dmfs.android.contentpal.operations.Assert;
+import org.dmfs.android.contentpal.operations.BulkDelete;
+import org.dmfs.android.contentpal.operations.Delete;
+import org.dmfs.android.contentpal.operations.Put;
+import org.dmfs.android.contentpal.operations.Referring;
+import org.dmfs.android.contentpal.predicates.AllOf;
+import org.dmfs.android.contentpal.predicates.EqArg;
+import org.dmfs.android.contentpal.queues.BasicOperationsQueue;
+import org.dmfs.android.contentpal.rowdata.Composite;
+import org.dmfs.android.contentpal.rowdata.EmptyRowData;
+import org.dmfs.android.contentpal.rowsnapshots.VirtualRowSnapshot;
+import org.dmfs.android.contenttestpal.operations.AssertEmptyTable;
+import org.dmfs.android.contenttestpal.operations.AssertRelated;
+import org.dmfs.opentaskspal.tables.InstanceTable;
+import org.dmfs.opentaskspal.tables.LocalTaskListsTable;
+import org.dmfs.opentaskspal.tables.TaskListScoped;
+import org.dmfs.opentaskspal.tables.TaskListsTable;
+import org.dmfs.opentaskspal.tables.TasksTable;
+import org.dmfs.opentaskspal.tasklists.NameData;
+import org.dmfs.opentaskspal.tasks.OriginalInstanceSyncIdData;
+import org.dmfs.opentaskspal.tasks.SyncIdData;
+import org.dmfs.opentaskspal.tasks.TimeData;
+import org.dmfs.opentaskspal.tasks.TitleData;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
+import org.dmfs.tasks.contract.TaskContract.Instances;
+import org.dmfs.tasks.contract.TaskContract.TaskLists;
+import org.dmfs.tasks.contract.TaskContract.Tasks;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.dmfs.android.contenttestpal.ContentMatcher.resultsIn;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Tests for {@link TaskProvider}.
+ *
+ * @author Yannic Ahrens
+ * @author Gabor Keszthelyi
+ */
+@RunWith(AndroidJUnit4.class)
+public class TaskProviderTest
+{
+    private ContentResolver mResolver;
+    private String mAuthority;
+    private Context mContext;
+    private ContentProviderClient mClient;
+
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mContext = InstrumentationRegistry.getTargetContext();
+        mResolver = mContext.getContentResolver();
+        mAuthority = AuthorityUtil.taskAuthority(mContext);
+        mClient = mContext.getContentResolver().acquireContentProviderClient(mAuthority);
+
+        // Assert that tables are empty:
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new MultiBatch(
+                new AssertEmptyTable<>(new TasksTable(mAuthority)),
+                new AssertEmptyTable<>(new TaskListsTable(mAuthority)),
+                new AssertEmptyTable<>(new InstanceTable(mAuthority))));
+        queue.flush();
+    }
+
+
+    @After
+    public void tearDown() throws Exception
+    {
+        /*
+        TODO When Test Orchestration is available, there will be no need for clean up here and check in setUp(), every test method will run in separate instrumentation
+        https://android-developers.googleblog.com/2017/07/android-testing-support-library-10-is.html
+        https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator
+        */
+
+        // Clear the DB:
+        BasicOperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new SingletonBatch(new BulkDelete<>(new LocalTaskListsTable(mAuthority))));
+        queue.flush();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            mClient.close();
+        }
+        else
+        {
+            mClient.release();
+        }
+    }
+
+
+    /**
+     * Create 1 local task list and 1 task, check values in TaskLists, TaskList, Instances tables.
+     */
+    @Test
+    public void testSingleInsert()
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        assertThat(new MultiBatch(
+                new Put<>(taskList, new NameData("list1")),
+                new Put<>(task, new TitleData("task1"))
+
+        ), resultsIn(mClient,
+                new Assert<>(taskList, new NameData("list1")),
+                new Assert<>(task, new TitleData("task1")),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task)
+        ));
+    }
+
+
+    /**
+     * Create 2 task list and 3 tasks, check values.
+     */
+    @Test
+    public void testMultipleInserts()
+    {
+        Table<TaskLists> taskListsTable = new LocalTaskListsTable(mAuthority);
+        RowSnapshot<TaskLists> taskList1 = new VirtualRowSnapshot<>(taskListsTable);
+        RowSnapshot<TaskLists> taskList2 = new VirtualRowSnapshot<>(taskListsTable);
+        RowSnapshot<Tasks> task1 = new VirtualRowSnapshot<>(new TaskListScoped(taskList1, new TasksTable(mAuthority)));
+        RowSnapshot<Tasks> task2 = new VirtualRowSnapshot<>(new TaskListScoped(taskList1, new TasksTable(mAuthority)));
+        RowSnapshot<Tasks> task3 = new VirtualRowSnapshot<>(new TaskListScoped(taskList2, new TasksTable(mAuthority)));
+
+        assertThat(new MultiBatch(
+                new Put<>(taskList1, new NameData("list1")),
+                new Put<>(taskList2, new NameData("list2")),
+                new Put<>(task1, new TitleData("task1")),
+                new Put<>(task2, new TitleData("task2")),
+                new Put<>(task3, new TitleData("task3"))
+
+        ), resultsIn(mClient,
+                new Assert<>(taskList1, new NameData("list1")),
+                new Assert<>(taskList2, new NameData("list2")),
+                new Assert<>(task1, new TitleData("task1")),
+                new Assert<>(task2, new TitleData("task2")),
+                new Assert<>(task3, new TitleData("task3")),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task1),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task2),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task3)
+        ));
+    }
+
+
+    /**
+     * Create task with start and due, check datetime values including generated duration.
+     */
+    @Test
+    public void testInsertTaskWithStartAndDue()
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        DateTime start = DateTime.now();
+        DateTime due = start.addDuration(new Duration(1, 1, 0));
+
+        assertThat(new MultiBatch(
+                new Put<>(taskList, new EmptyRowData<TaskLists>()),
+                new Put<>(task, new TimeData(start, due))
+
+        ), resultsIn(mClient,
+                new Assert<>(task, new TimeData(start, due)),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task, new AllOf(
+                        new EqArg(Instances.INSTANCE_START, start.getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DUE, due.getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DURATION, due.getTimestamp() - start.getTimestamp()),
+                        new EqArg(Tasks.TZ, start.isAllDay() ? "UTC" : start.getTimeZone().getID())
+                ))
+        ));
+    }
+
+
+    /**
+     * Create task with start and duration, check datetime values including generated due.
+     */
+    @Test
+    public void testInsertWithStartAndDuration()
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        DateTime start = DateTime.now();
+        Duration duration = Duration.parse("PT1H");
+        long durationMillis = duration.toMillis();
+
+        assertThat(new MultiBatch(
+                new Put<>(taskList, new EmptyRowData<TaskLists>()),
+                new Put<>(task, new TimeData(start, duration))
+
+        ), resultsIn(mClient,
+                new Assert<>(task, new TimeData(start, duration)),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task, new AllOf(
+                        new EqArg(Instances.INSTANCE_START, start.getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DUE, start.addDuration(duration).getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DURATION, durationMillis),
+                        new EqArg(Tasks.TZ, "UTC")
+                ))
+        ));
+    }
+
+
+    /**
+     * Having a task with start and due.
+     * Update it with different due, check datetime values correct in Tasks and Instances.
+     */
+    @Test
+    public void testUpdateDue() throws Exception
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        DateTime start = DateTime.now();
+        DateTime due = start.addDuration(new Duration(1, 0, 1));
+
+        queue.enqueue(new MultiBatch(
+                new Put<>(taskList, new NameData("list1")),
+                new Put<>(task, new TimeData(start, due))
+        ));
+        queue.flush();
+
+        DateTime due2 = due.addDuration(new Duration(1, 0, 2));
+
+        assertThat(new SingletonBatch(
+                new Put<>(task, new TimeData(start, due2))
+
+        ), resultsIn(queue,
+                new Assert<>(task, new TimeData(start, due2)),
+                new AssertRelated<>(new InstanceTable(mAuthority), Instances.TASK_ID, task, new AllOf(
+                        new EqArg(Instances.INSTANCE_START, start.getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DUE, due2.getTimestamp()),
+                        new EqArg(Instances.INSTANCE_DURATION, due2.getTimestamp() - start.getTimestamp()),
+                        new EqArg(Tasks.TZ, "UTC")
+                ))
+        ));
+    }
+
+
+    /**
+     * Having a single task.
+     * Delete task, check that it is removed from Tasks and Instances tables.
+     */
+    @Test
+    public void testInstanceDelete() throws Exception
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Tasks> taskTable = new TaskListScoped(taskList, new TasksTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(taskTable);
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        queue.enqueue(new MultiBatch(
+                new Put<>(taskList, new NameData("list1")),
+                new Put<>(task, new TitleData("task1"))
+        ));
+        queue.flush();
+
+        assertThat(new SingletonBatch(
+                new Delete<>(task)
+
+        ), resultsIn(queue,
+                new AssertEmptyTable<>(new TasksTable(mAuthority)),
+                new AssertEmptyTable<>(new InstanceTable(mAuthority))
+        ));
+    }
+
+
+    /**
+     * Contract: LIST_ID is required on task creation.
+     * <p>
+     * Create task without LIST_ID, check for IllegalArgumentException.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertWithOutListId() throws Exception
+    {
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TasksTable(mAuthority));
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new SingletonBatch(new Put<>(task, new TitleData("task1"))));
+        queue.flush();
+    }
+
+
+    /**
+     * Contract: LIST_ID has to refer to existing TaskList.
+     * <p>
+     * Create task with a non-exsiting LIST_ID, check for IllegalArgumentException.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertWithInvalidTaskListId()
+    {
+        ContentValues values = new ContentValues();
+        values.put(Tasks.LIST_ID, 5);
+        mResolver.insert(Tasks.getContentUri(mAuthority), values);
+    }
+
+
+    /**
+     * Contract: Setting ORIGINAL_INSTANCE_SYNC_ID for an exception task,
+     * provider must fill ORIGINAL_INSTANCE_ID with corresponding original task's _ID.
+     */
+    @Test
+    public void testExceptionalInstance_settingSyncId_shouldUpdateRegularId() throws Exception
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Tasks> taskTable = new TaskListScoped(taskList, new TasksTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(taskTable);
+        RowSnapshot<Tasks> exceptionTask = new VirtualRowSnapshot<>(taskTable);
+
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        queue.enqueue(new MultiBatch(
+                new Put<>(taskList, new NameData("list1")),
+                new Put<>(task, new Composite<>(
+                        new TitleData("task1"),
+                        new SyncIdData("syncId1"))
+                )
+        ));
+        queue.flush();
+
+        assertThat(new SingletonBatch(
+                new Put<>(exceptionTask, new Composite<>(
+                        new TitleData("task1exception"),
+                        new OriginalInstanceSyncIdData("syncId1"))
+                )
+
+        ), resultsIn(queue,
+                new AssertRelated<>(new TasksTable(mAuthority), Tasks.ORIGINAL_INSTANCE_ID, task, new TitleData("task1exception"))
+        ));
+    }
+
+
+    /**
+     * Contract: Setting ORIGINAL_INSTANCE_ID for an exception task,
+     * provider must fill ORIGINAL_INSTANCE_SYNC_ID with corresponding original task's _SYNC_ID.
+     */
+    @Test
+    public void testExceptionalInstance_settingRegularId_shouldUpdateSyncId() throws Exception
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Tasks> taskTable = new TaskListScoped(taskList, new TasksTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(taskTable);
+        RowSnapshot<Tasks> exceptionTask = new VirtualRowSnapshot<>(taskTable);
+
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        queue.enqueue(new MultiBatch(
+                new Put<>(taskList, new NameData("list1")),
+                new Put<>(task, new Composite<>(
+                        new TitleData("task1"),
+                        new SyncIdData("syncId1"))
+                )
+        ));
+        queue.flush();
+
+        assertThat(new SingletonBatch(
+                new Referring<>(task, Tasks.ORIGINAL_INSTANCE_ID,
+                        new Put<>(exceptionTask, new TitleData("task1exception")))
+
+        ), resultsIn(queue,
+                new AssertRelated<>(new TasksTable(mAuthority), Tasks.ORIGINAL_INSTANCE_ID, task,
+                        new Composite<>(
+                                new TitleData("task1exception"),
+                                new OriginalInstanceSyncIdData("syncId1")
+                        ))
+        ));
+    }
+
+}

--- a/opentasks-provider/src/androidTest/res/values/opentasks_defaults.xml
+++ b/opentasks-provider/src/androidTest/res/values/opentasks_defaults.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- The name of the task authority. -->
+    <string name="opentasks_authority"
+            translatable="false">org.dmfs.tasks.test
+    </string>
+
+</resources>

--- a/opentasks-provider/src/main/AndroidManifest.xml
+++ b/opentasks-provider/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         package="org.dmfs.tasks.provider">
 
     <permission
@@ -15,6 +16,9 @@
             android:protectionLevel="dangerous"/>
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+
+    <!--TODO Remove after https://github.com/dmfs/opentasks/issues/392-->
+    <uses-sdk tools:overrideLibrary="org.dmfs.android.contenttestpal"/>
 
     <application>
         <provider

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/AuthorityUtil.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/AuthorityUtil.java
@@ -17,84 +17,27 @@
 package org.dmfs.provider.tasks;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ProviderInfo;
 
-import org.dmfs.tasks.contract.UriFactory;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import org.dmfs.tasks.provider.R;
 
 
 /**
- * TODO
+ * Access for the authority name of the tasks content provider.
+ *
+ * @author Gabor Keszthelyi
  */
+// TODO Figure out better design or at least rename to TaskAuthority.get(context) (results in changes in many files)
 public final class AuthorityUtil
 {
-    /**
-     * The task authority cache.
-     */
-    private static Map<String, String> sAuthorities = Collections.synchronizedMap(new HashMap<String, String>(4));
+    private static String sCachedValue;
 
 
-    /**
-     * Returns the authority of the {@link TaskProvider} in the given {@link Context}.
-     * <p/>
-     * TODO: create an Authority class instead that handles everything about authorities. It could replace {@link UriFactory} as well. The Authority class could
-     * have a generic parameter that identifies the authority provider or contract class.
-     *
-     * @param context
-     *         A {@link Context} of an app that contains a {@link TaskProvider}.
-     *
-     * @return The authority.
-     *
-     * @throws RuntimeException
-     *         if there is no {@link TaskProvider} in that {@link Context}.
-     */
-    public static synchronized String taskAuthority(Context context)
+    public static String taskAuthority(Context context)
     {
-        String packageName = context.getPackageName();
-        if (sAuthorities.containsKey(packageName))
+        if (sCachedValue == null)
         {
-            return sAuthorities.get(packageName);
+            sCachedValue = context.getString(R.string.opentasks_authority);
         }
-
-        PackageManager packageManager = context.getPackageManager();
-
-        // first get the PackageInfo of this app.
-        PackageInfo packageInfo;
-        try
-        {
-            packageInfo = packageManager.getPackageInfo(context.getPackageName(), PackageManager.GET_PROVIDERS);
-        }
-        catch (PackageManager.NameNotFoundException e)
-        {
-            throw new RuntimeException("Could not find TaskProvider!", e);
-        }
-
-        // next scan all providers for TaskProvider
-        for (ProviderInfo provider : packageInfo.providers)
-        {
-            Class<?> providerClass;
-            try
-            {
-                providerClass = Class.forName(provider.name);
-            }
-            catch (ClassNotFoundException e)
-            {
-                continue;
-            }
-
-            if (!TaskProvider.class.isAssignableFrom(providerClass))
-            {
-                continue;
-            }
-
-            sAuthorities.put(packageName, provider.authority);
-            return provider.authority;
-        }
-        throw new RuntimeException("Could not find TaskProvider! Make sure you added it to your AndroidManifest.xml.");
+        return sCachedValue;
     }
 }


### PR DESCRIPTION
Remove dynamic authority resolution in AuthorityUtil.

---

Submitting this now for first check. There are many TODOs left in code.

A few specific notes:
- opentaskpal classes are not reviewed yet
- the contentpal test support ended up being one simple `Matcher` class basically, but I used this `Check` type to implement it and make an adapter for `Matcher`. I haven't thought it through yet since things got much more simple with the `Assert` operations. One thing is that `Matcher` seems not to be completely straighforward for me with the 3 base classes, also I think what we do here is more an execution which can throw Exception than a simple comparison of an already calculated value, so that's why this interface may be better.
We could also forget the hamcrest assert as well, I suppose, to write something like:
```
execute(batch).with(client).andVerifyContent(assertOperations)
```
with our own types.
Implementation may depend a little bit on the eager queue stuff as well.
- not sure where the convenience `Assert*` composed operations should go, to contentpal module or contentpal-testing module
- I've left `AA_TO_*` package names to indicate which module the sibling packages are intended to end up in
- There is one bigger test case left in original form, I will update that, too, so the related private methods can be removed as well
- All test cases are based on the original ones from the old code
- There are possible ways to improve the test code usage, there are some issues to be solved as well (TODOs in code)
- `Assert` for `RowSnapshot` is not available yet, so that will result in changes as well

This is a single commit now, I will continue to commit on top of it.