### PR TITLE
Exclude META-INF in opentaskpal gradle packagingOptions to fix CI bui…

### DIFF
--- a/opentaskspal/build.gradle
+++ b/opentaskspal/build.gradle
@@ -8,6 +8,10 @@ android {
         minSdkVersion MIN_SDK_VERSION.toInteger()
         targetSdkVersion TARGET_SDK_VERSION.toInteger()
     }
+    packagingOptions {
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
…ld. #440

---

I've added the packagingOptions exclude, although it had built for me without it as well, so I don't know if this fixes the issue. Was it a maven build task or Travis that failed?