### PR TITLE
Add .travis.yml. Implements #417

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: android
+sudo: false
+
+android:
+  components:
+    - tools
+    - platform-tools
+    - tools
+    - build-tools-25.0.3
+    - android-24
+    - android-25
+    - extra-android-m2repository
+    - sys-img-armeabi-v7a-android-24
+
+# Emulator Management: Create, Start and Wait
+before_script:
+  - echo no | android create avd --force -n test --target android-24 --abi armeabi-v7a
+  - QEMU_AUDIO_DRV=none emulator -avd test -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
+script:
+  - android list target
+  - ./gradlew connectedAndroidTest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/dmfs/opentasks.svg?branch=master)](https://travis-ci.org/dmfs/opentasks)
 # OpenTasks
 
 __An Open Source Task App for Android__

--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.application'
 def gitCommitNo = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-list', '--count', 'master'
+        commandLine 'git', 'rev-list', '--count', 'HEAD'
         standardOutput = stdout
     }
     return Integer.parseInt(stdout.toString().trim())
@@ -17,7 +17,7 @@ android {
         applicationId "org.dmfs.tasks"
         minSdkVersion MIN_SDK_VERSION.toInteger()
         targetSdkVersion TARGET_SDK_VERSION.toInteger()
-        versionCode gitCommitNo()
+        versionCode gitCommitNo() * 10 // spread version code to allow inserting versions if necessary
         versionName version
     }
     buildTypes {


### PR DESCRIPTION
This also changes the version code to be based on commit count in the current branch rather than master. Apparently Travis doesn't fetch the master which caused this to fail.
Since we only publish master builds this should not have any unwanted side effects. Yet we spread the version code to allow inserting version numbers if necessary.