### PR TITLE
Use alarmmanager.setExact() for timeout schedule in NotificationUtils…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationActionUtils.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/NotificationActionUtils.java
@@ -323,7 +323,14 @@ public class NotificationActionUtils
         final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         final long triggerAtMills = SystemClock.elapsedRealtime() + sUndoTimeoutMillis;
         final PendingIntent pendingIntent = createUndoTimeoutPendingIntent(context, notificationAction);
-        alarmManager.set(AlarmManager.ELAPSED_REALTIME, triggerAtMills, pendingIntent);
+        if (VERSION.SDK_INT >= VERSION_CODES.KITKAT)
+        {
+            alarmManager.setExact(AlarmManager.ELAPSED_REALTIME, triggerAtMills, pendingIntent);
+        }
+        else
+        {
+            alarmManager.set(AlarmManager.ELAPSED_REALTIME, triggerAtMills, pendingIntent);
+        }
     }
 
 


### PR DESCRIPTION
…. #468

---

Just a note, that I though about the possibility to improve the codes for setting up alarms with something like:
```java
interface Alarm
{
      void set(Context context);
}
```
and have implementations to enable re-use, they would handle Android version routing, too,
but since this ticket required so little change, I though the refactor is not worth it at this point.