### PR TITLE
Fix CI build issue of not finding git tag. #486

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', '--always'
         standardOutput = stdout
     }
     return stdout.toString().trim()


### PR DESCRIPTION
As suggested, the `--always` flag is added to the `git describe --tags` command in the gradle file to avoid exiting when no tags found in the shallow clone on the CI.