### PR TITLE
Mark RTL as not supported, disable IDE warning. #489

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidLintRtlHardcoded" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:label="@string/app_name"
             android:name=".TasksApplication"
             android:taskAffinity="org.dmfs.tasks.TaskListActivity"
+            android:supportsRtl="false"
             android:theme="@style/OpenTasksAppTheme">
 
         <!-- TaskListActivity listens for MAIN intents -->


### PR DESCRIPTION
This marks RTL as not supported in the manifest and also adds inspection configuration for Android Studio to ignore that warning, since as it seems it can't pick it up automatically from that manifest attribute.