### PR TITLE
Fix 12/24h format on event list due date-time by using an 5.1.1 Andro…

### DIFF
--- a/opentasks/src/main/res/values-cs/strings.xml
+++ b/opentasks/src/main/res/values-cs/strings.xml
@@ -250,4 +250,6 @@
     <!-- Sharing intent -->
     <string name="share_as_task">Vytvořit úkol</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-fr/strings.xml
+++ b/opentasks/src/main/res/values-fr/strings.xml
@@ -249,4 +249,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Ajouter une tâche</string>
 
+    <string name="opentasks_date_time">%1$s à %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-hu/strings.xml
+++ b/opentasks/src/main/res/values-hu/strings.xml
@@ -254,4 +254,6 @@
     <!-- Outgoing share -->
     <string name="opentasks_share_footer">OpenTasks-al küldve</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-it/strings.xml
+++ b/opentasks/src/main/res/values-it/strings.xml
@@ -118,4 +118,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Aggiungi attività</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-ja/strings.xml
+++ b/opentasks/src/main/res/values-ja/strings.xml
@@ -249,4 +249,7 @@
     <!-- Incoming share -->
     <string name="share_as_task">タスクを作成</string>
 
+    <string name="opentasks_relative_time">%1$s %2$s</string>
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-nl/strings.xml
+++ b/opentasks/src/main/res/values-nl/strings.xml
@@ -245,4 +245,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Taak toevoegen</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-pl/strings.xml
+++ b/opentasks/src/main/res/values-pl/strings.xml
@@ -241,4 +241,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Dodaj zadanie</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-pt-rPT/strings.xml
+++ b/opentasks/src/main/res/values-pt-rPT/strings.xml
@@ -261,4 +261,6 @@
     <!-- Notification "Pulse light" enabling/disabling entry label in settings -->
     <string name="opentasks_settings_notification_lights">Luz</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-pt-rbr/strings.xml
+++ b/opentasks/src/main/res/values-pt-rbr/strings.xml
@@ -239,4 +239,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Adicionar tarefa</string>
 
+    <string name="opentasks_date_time">%1$s %2$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-ru/strings.xml
+++ b/opentasks/src/main/res/values-ru/strings.xml
@@ -219,4 +219,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Добавить задачу</string>
 
+    <string name="opentasks_date_time">%2$s, %1$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-sk/strings.xml
+++ b/opentasks/src/main/res/values-sk/strings.xml
@@ -251,4 +251,6 @@
     <!-- Sharing intent -->
     <string name="share_as_task">Vytvoriť úlohu</string>
 
+    <string name="opentasks_date_time">%2$s %1$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-sr/strings.xml
+++ b/opentasks/src/main/res/values-sr/strings.xml
@@ -239,4 +239,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Додај задатак</string>
 
+    <string name="opentasks_date_time">%2$s %1$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values-uk/strings.xml
+++ b/opentasks/src/main/res/values-uk/strings.xml
@@ -239,4 +239,6 @@
     <!-- Incoming share -->
     <string name="share_as_task">Нове завдання</string>
 
+    <string name="opentasks_date_time">%2$s %1$s</string>
+
 </resources>

--- a/opentasks/src/main/res/values/strings.xml
+++ b/opentasks/src/main/res/values/strings.xml
@@ -273,4 +273,9 @@
     <string name="opentasks_permission_request_dialog_getaccounts_button_continue">Continue</string>
     <string name="opentasks_permission_request_dialog_getaccounts_button_settings">Open Settings</string>
 
+    <!-- Format indicating a relative expression and time. Example: "4 hours ago, 11:00 am" -->
+    <string name="opentasks_relative_time">%1$s, %2$s</string>
+    <!-- Format indicating a date and time. Example: "23 Aug, 11:00 am" -->
+    <string name="opentasks_date_time">%1$s, %2$s</string>
+
 </resources>


### PR DESCRIPTION
…id version of the DateUtils method. #396 

---

Fixed it as discussed on chat.
I just added the old version of the method as a private method of `DateFormatter` as I assume it's best to keep every date-time formatting code there until `Time` is removed form the project. We can refactor after that.

Btw, found the bug on the official tracker: https://issuetracker.google.com/issues/37127319