### PR TITLE
Fix crash when opening Edit screen from widget while no accounts perm…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskActivity.java
@@ -173,10 +173,6 @@ public class EditTaskActivity extends BaseActivity
         {
             mEditFragment = (EditTaskFragment) fragment;
         }
-        else
-        {
-            throw new IllegalArgumentException("Invalid fragment attached: " + fragment.getClass().getCanonicalName());
-        }
     }
 
 


### PR DESCRIPTION
…ission had been granted. #507 

---

`EditTaskActivity` was validating that only `EditTaskFragment` can be attached to it. I've removed that as it seems unnecessary and causes crash for any `DialogFragment` like in this case.