### PR TITLE
Fix an NPE by adding a null-check on ContentSet in EditTaskFragment o…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
@@ -296,9 +296,13 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
                         // ensure we're using the latest values
                         mValues.update(mAppContext, CONTENT_VALUE_MAPPER);
                     }
-                    mListColor = TaskFieldAdapters.LIST_COLOR.get(mValues);
-                    // update the color of the action bar as soon as possible
-                    updateColor(0);
+
+                    if (mValues != null)
+                    {
+                        mListColor = TaskFieldAdapters.LIST_COLOR.get(mValues);
+                        // update the color of the action bar as soon as possible
+                        updateColor(0);
+                    }
                     setListUri(TaskLists.getContentUri(mAuthority), LIST_LOADER_VISIBLE_LISTS_FILTER);
                 }
             }


### PR DESCRIPTION
…nCreateView. #511 

---

I simply added a null check around the point where the NPE came from.
The logic in this `EditTaskFragment` is rather tangled, so please check yourself too that the change makes sense and fits the logic. I also don't know how to reproduce the crash.

(I expect that if/when we replace `ContentSet` and the loading with RxJava, then this `Fragment` would be simplified significantly, so I assume it's not worth trying to improve on the current code and solution.)