### PR TITLE
Fix crashes caused by CREATE INDEX SQL commands upon DB update by add…

### DIFF
--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
@@ -533,7 +533,7 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
         {
             buffer.append(" UNIQUE ");
         }
-        buffer.append("INDEX ");
+        buffer.append("INDEX IF NOT EXISTS ");
         buffer.append(table).append("_").append(fields[0]).append("_idx ON ");
         buffer.append(table).append(" (");
         buffer.append(fields[0]);


### PR DESCRIPTION
…ing IF NOT EXISTS clause. #382 

---
Steps to reproduce the crash:
- clean install from master with `TaskDatabaseHelper#DATABASE_VERSION = 15`
(may also need `allowBackup=false` in manifest)
- add tasks
- install update with version `TaskDatabaseHelper#DATABASE_VERSION = 16`

Doing the same with this branch should not result in a crash.