### PR TITLE
Move instance processing to TransactionEndTask. Implements #537

### DIFF
--- a/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
+++ b/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
@@ -781,6 +781,15 @@ public final class TaskContract
         String ORIGINAL_INSTANCE_ALLDAY = "original_instance_allday";
 
         /**
+         * A flag indicating that the instances of this task may have to be recalculated because either date-time, recurrence or status have been updated.
+         * <p>
+         * Value: Integer (0 or 1)
+         * <p>
+         * Read-only
+         */
+        String INSTANCES_STALE = "instances_stale";
+
+        /**
          * The row id of the parent task. <code>null</code> if the task has no parent task.
          * <p>
          * Value: Long

--- a/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
+++ b/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
@@ -781,15 +781,6 @@ public final class TaskContract
         String ORIGINAL_INSTANCE_ALLDAY = "original_instance_allday";
 
         /**
-         * A flag indicating that the instances of this task may have to be recalculated because either date-time, recurrence or status have been updated.
-         * <p>
-         * Value: Integer (0 or 1)
-         * <p>
-         * Read-only
-         */
-        String INSTANCES_STALE = "instances_stale";
-
-        /**
          * The row id of the parent task. <code>null</code> if the task has no parent task.
          * <p>
          * Value: Long

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/SQLiteContentProvider.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/SQLiteContentProvider.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.decorators.Flattened;
+import org.dmfs.provider.tasks.transactionendtasks.TransactionEndTask;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -48,12 +49,6 @@ import java.util.Set;
  */
 abstract class SQLiteContentProvider extends ContentProvider
 {
-
-    interface TransactionEndTask
-    {
-        void execute(SQLiteDatabase database);
-    }
-
 
     @SuppressWarnings("unused")
     private static final String TAG = "SQLiteContentProvider";

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
@@ -36,7 +36,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.text.TextUtils;
 
-import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.provider.tasks.TaskDatabaseHelper.OnDatabaseOperationListener;
 import org.dmfs.provider.tasks.TaskDatabaseHelper.Tables;
 import org.dmfs.provider.tasks.handler.PropertyHandler;
@@ -56,6 +56,8 @@ import org.dmfs.provider.tasks.processors.tasks.Relating;
 import org.dmfs.provider.tasks.processors.tasks.Searchable;
 import org.dmfs.provider.tasks.processors.tasks.TaskCommitProcessor;
 import org.dmfs.provider.tasks.processors.tasks.Validating;
+import org.dmfs.provider.tasks.transactionendtasks.TransactionEndTask;
+import org.dmfs.provider.tasks.transactionendtasks.UpdateInstancesTask;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Alarms;
 import org.dmfs.tasks.contract.TaskContract.Categories;
@@ -145,8 +147,7 @@ public final class TaskProvider extends SQLiteContentProvider implements OnAccou
 
     public TaskProvider()
     {
-        // for now we don't have anything specific to execute before the transaction ends.
-        super(EmptyIterable.<TransactionEndTask>instance());
+        super(new Seq<TransactionEndTask>(new UpdateInstancesTask()));
     }
 
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
@@ -44,275 +44,280 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
     /**
      * Adapter for the row id of a task.
      */
-    public final static LongFieldAdapter<TaskAdapter> _ID = new LongFieldAdapter<TaskAdapter>(Tasks._ID);
+    LongFieldAdapter<TaskAdapter> _ID = new LongFieldAdapter<TaskAdapter>(Tasks._ID);
 
     /**
      * Adapter for the task row id of as instance.
      */
-    public final static LongFieldAdapter<TaskAdapter> INSTANCE_TASK_ID = new LongFieldAdapter<TaskAdapter>(Instances.TASK_ID);
+    LongFieldAdapter<TaskAdapter> INSTANCE_TASK_ID = new LongFieldAdapter<TaskAdapter>(Instances.TASK_ID);
 
     /**
      * Adapter for the row id of the list of a task.
      */
-    public final static LongFieldAdapter<TaskAdapter> LIST_ID = new LongFieldAdapter<TaskAdapter>(Tasks.LIST_ID);
+    LongFieldAdapter<TaskAdapter> LIST_ID = new LongFieldAdapter<TaskAdapter>(Tasks.LIST_ID);
 
     /**
      * Adapter for the owner of the list of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> LIST_OWNER = new StringFieldAdapter<TaskAdapter>(Tasks.LIST_OWNER);
+    StringFieldAdapter<TaskAdapter> LIST_OWNER = new StringFieldAdapter<TaskAdapter>(Tasks.LIST_OWNER);
 
     /**
      * Adapter for the row id of original instance of a task.
      */
-    public final static LongFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_ID = new LongFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_ID);
+    LongFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_ID = new LongFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_ID);
 
     /**
      * Adapter for the sync_id of original instance of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_SYNC_ID = new StringFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_SYNC_ID);
+    StringFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_SYNC_ID = new StringFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_SYNC_ID);
 
     /**
      * Adapter for the all day flag of a task.
      */
-    public final static BooleanFieldAdapter<TaskAdapter> IS_ALLDAY = new BooleanFieldAdapter<TaskAdapter>(Tasks.IS_ALLDAY);
+    BooleanFieldAdapter<TaskAdapter> IS_ALLDAY = new BooleanFieldAdapter<TaskAdapter>(Tasks.IS_ALLDAY);
 
     /**
      * Adapter for the percent complete value of a task.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> PERCENT_COMPLETE = new IntegerFieldAdapter<TaskAdapter>(Tasks.PERCENT_COMPLETE);
+    IntegerFieldAdapter<TaskAdapter> PERCENT_COMPLETE = new IntegerFieldAdapter<TaskAdapter>(Tasks.PERCENT_COMPLETE);
 
     /**
      * Adapter for the status of a task.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> STATUS = new IntegerFieldAdapter<TaskAdapter>(Tasks.STATUS);
+    IntegerFieldAdapter<TaskAdapter> STATUS = new IntegerFieldAdapter<TaskAdapter>(Tasks.STATUS);
 
     /**
      * Adapter for the priority value of a task.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> PRIORITY = new IntegerFieldAdapter<TaskAdapter>(Tasks.PRIORITY);
+    IntegerFieldAdapter<TaskAdapter> PRIORITY = new IntegerFieldAdapter<TaskAdapter>(Tasks.PRIORITY);
 
     /**
      * Adapter for the classification value of a task.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> CLASSIFICATION = new IntegerFieldAdapter<TaskAdapter>(Tasks.CLASSIFICATION);
+    IntegerFieldAdapter<TaskAdapter> CLASSIFICATION = new IntegerFieldAdapter<TaskAdapter>(Tasks.CLASSIFICATION);
 
     /**
      * Adapter for the list name of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> LIST_NAME = new StringFieldAdapter<TaskAdapter>(Tasks.LIST_NAME);
+    StringFieldAdapter<TaskAdapter> LIST_NAME = new StringFieldAdapter<TaskAdapter>(Tasks.LIST_NAME);
 
     /**
      * Adapter for the account name of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> ACCOUNT_NAME = new StringFieldAdapter<TaskAdapter>(Tasks.ACCOUNT_NAME);
+    StringFieldAdapter<TaskAdapter> ACCOUNT_NAME = new StringFieldAdapter<TaskAdapter>(Tasks.ACCOUNT_NAME);
 
     /**
      * Adapter for the account type of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> ACCOUNT_TYPE = new StringFieldAdapter<TaskAdapter>(Tasks.ACCOUNT_TYPE);
+    StringFieldAdapter<TaskAdapter> ACCOUNT_TYPE = new StringFieldAdapter<TaskAdapter>(Tasks.ACCOUNT_TYPE);
 
     /**
      * Adapter for the title of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> TITLE = new StringFieldAdapter<TaskAdapter>(Tasks.TITLE);
+    StringFieldAdapter<TaskAdapter> TITLE = new StringFieldAdapter<TaskAdapter>(Tasks.TITLE);
 
     /**
      * Adapter for the location of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> LOCATION = new StringFieldAdapter<TaskAdapter>(Tasks.LOCATION);
+    StringFieldAdapter<TaskAdapter> LOCATION = new StringFieldAdapter<TaskAdapter>(Tasks.LOCATION);
 
     /**
      * Adapter for the description of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> DESCRIPTION = new StringFieldAdapter<TaskAdapter>(Tasks.DESCRIPTION);
+    StringFieldAdapter<TaskAdapter> DESCRIPTION = new StringFieldAdapter<TaskAdapter>(Tasks.DESCRIPTION);
 
     /**
      * Adapter for the start date of a task.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> DTSTART = new DateTimeFieldAdapter<TaskAdapter>(Tasks.DTSTART, Tasks.TZ, Tasks.IS_ALLDAY);
+    DateTimeFieldAdapter<TaskAdapter> DTSTART = new DateTimeFieldAdapter<TaskAdapter>(Tasks.DTSTART, Tasks.TZ, Tasks.IS_ALLDAY);
 
     /**
      * Adapter for the raw start date timestamp of a task.
      */
-    public final static LongFieldAdapter<TaskAdapter> DTSTART_RAW = new LongFieldAdapter<TaskAdapter>(Tasks.DTSTART);
+    LongFieldAdapter<TaskAdapter> DTSTART_RAW = new LongFieldAdapter<TaskAdapter>(Tasks.DTSTART);
 
     /**
      * Adapter for the due date of a task.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> DUE = new DateTimeFieldAdapter<TaskAdapter>(Tasks.DUE, Tasks.TZ, Tasks.IS_ALLDAY);
+    DateTimeFieldAdapter<TaskAdapter> DUE = new DateTimeFieldAdapter<TaskAdapter>(Tasks.DUE, Tasks.TZ, Tasks.IS_ALLDAY);
 
     /**
      * Adapter for the raw due date timestamp of a task.
      */
-    public final static LongFieldAdapter<TaskAdapter> DUE_RAW = new LongFieldAdapter<TaskAdapter>(Tasks.DUE);
+    LongFieldAdapter<TaskAdapter> DUE_RAW = new LongFieldAdapter<TaskAdapter>(Tasks.DUE);
 
     /**
      * Adapter for the start date of a task.
      */
-    public final static DurationFieldAdapter<TaskAdapter> DURATION = new DurationFieldAdapter<TaskAdapter>(Tasks.DURATION);
+    DurationFieldAdapter<TaskAdapter> DURATION = new DurationFieldAdapter<TaskAdapter>(Tasks.DURATION);
 
     /**
      * Adapter for the dirty flag of a task.
      */
-    public final static BooleanFieldAdapter<TaskAdapter> _DIRTY = new BooleanFieldAdapter<TaskAdapter>(Tasks._DIRTY);
+    BooleanFieldAdapter<TaskAdapter> _DIRTY = new BooleanFieldAdapter<TaskAdapter>(Tasks._DIRTY);
 
     /**
      * Adapter for the deleted flag of a task.
      */
-    public final static BooleanFieldAdapter<TaskAdapter> _DELETED = new BooleanFieldAdapter<TaskAdapter>(Tasks._DELETED);
+    BooleanFieldAdapter<TaskAdapter> _DELETED = new BooleanFieldAdapter<TaskAdapter>(Tasks._DELETED);
 
     /**
      * Adapter for the completed date of a task.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> COMPLETED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.COMPLETED, null, null);
+    DateTimeFieldAdapter<TaskAdapter> COMPLETED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.COMPLETED, null, null);
 
     /**
      * Adapter for the created date of a task.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> CREATED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.CREATED, null, null);
+    DateTimeFieldAdapter<TaskAdapter> CREATED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.CREATED, null, null);
 
     /**
      * Adapter for the last modified date of a task.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> LAST_MODIFIED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.LAST_MODIFIED, null, null);
+    DateTimeFieldAdapter<TaskAdapter> LAST_MODIFIED = new DateTimeFieldAdapter<TaskAdapter>(Tasks.LAST_MODIFIED, null, null);
 
     /**
      * Adapter for the URL of a task.
      */
-    public final static UrlFieldAdapter<TaskAdapter> URL = new UrlFieldAdapter<TaskAdapter>(TaskContract.Tasks.URL);
+    UrlFieldAdapter<TaskAdapter> URL = new UrlFieldAdapter<TaskAdapter>(TaskContract.Tasks.URL);
 
     /**
      * Adapter for the UID of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> _UID = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks._UID);
+    StringFieldAdapter<TaskAdapter> _UID = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks._UID);
 
     /**
      * Adapter for the raw time zone of a task.
      */
-    public final static StringFieldAdapter<TaskAdapter> TIMEZONE_RAW = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks.TZ);
+    StringFieldAdapter<TaskAdapter> TIMEZONE_RAW = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks.TZ);
 
     /**
      * Adapter for the Color of the task.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> LIST_COLOR = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.LIST_COLOR);
+    IntegerFieldAdapter<TaskAdapter> LIST_COLOR = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.LIST_COLOR);
 
     /**
      * Adapter for the access level of the task list.
      */
-    public final static IntegerFieldAdapter<TaskAdapter> LIST_ACCESS_LEVEL = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.LIST_ACCESS_LEVEL);
+    IntegerFieldAdapter<TaskAdapter> LIST_ACCESS_LEVEL = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.LIST_ACCESS_LEVEL);
 
     /**
      * Adapter for the visibility setting of the task list.
      */
-    public final static BooleanFieldAdapter<TaskAdapter> LIST_VISIBLE = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.VISIBLE);
+    BooleanFieldAdapter<TaskAdapter> LIST_VISIBLE = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.VISIBLE);
 
     /**
      * Adpater for the ID of the task.
      */
-    public static final IntegerFieldAdapter<TaskAdapter> TASK_ID = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks._ID);
+    IntegerFieldAdapter<TaskAdapter> TASK_ID = new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks._ID);
 
     /**
      * Adapter for the IS_CLOSED flag of a task.
      */
-    public static final BooleanFieldAdapter<TaskAdapter> IS_CLOSED = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.IS_CLOSED);
+    BooleanFieldAdapter<TaskAdapter> IS_CLOSED = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.IS_CLOSED);
 
     /**
      * Adapter for the IS_NEW flag of a task.
      */
-    public static final BooleanFieldAdapter<TaskAdapter> IS_NEW = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.IS_NEW);
+    BooleanFieldAdapter<TaskAdapter> IS_NEW = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.IS_NEW);
 
     /**
      * Adapter for the PINNED flag of a task.
      */
-    public static final BooleanFieldAdapter<TaskAdapter> PINNED = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.PINNED);
+    BooleanFieldAdapter<TaskAdapter> PINNED = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.PINNED);
 
     /**
      * Adapter for the HAS_ALARMS flag of a task.
      */
-    public static final BooleanFieldAdapter<TaskAdapter> HAS_ALARMS = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.HAS_ALARMS);
+    BooleanFieldAdapter<TaskAdapter> HAS_ALARMS = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.HAS_ALARMS);
+
+    /**
+     * Adapter for the {@link TaskContract.Tasks#INSTANCES_STALE} flag of a task.
+     */
+    BooleanFieldAdapter<TaskAdapter> INSTANCES_STALE = new BooleanFieldAdapter<>(Tasks.INSTANCES_STALE);
 
     /**
      * Adapter for the HAS_PROPERTIES flag of a task.
      */
-    public static final BooleanFieldAdapter<TaskAdapter> HAS_PROPERTIES = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.HAS_PROPERTIES);
+    BooleanFieldAdapter<TaskAdapter> HAS_PROPERTIES = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.HAS_PROPERTIES);
 
     /**
      * Adapter for the RRULE of a task.
      */
-    public static final RRuleFieldAdapter<TaskAdapter> RRULE = new RRuleFieldAdapter<TaskAdapter>(TaskContract.Tasks.RRULE);
+    RRuleFieldAdapter<TaskAdapter> RRULE = new RRuleFieldAdapter<TaskAdapter>(TaskContract.Tasks.RRULE);
 
     /**
      * Adapter for the RDATE of a task.
      */
-    public static final DateTimeArrayFieldAdapter<TaskAdapter> RDATE = new DateTimeArrayFieldAdapter<TaskAdapter>(TaskContract.Tasks.RDATE,
+    DateTimeArrayFieldAdapter<TaskAdapter> RDATE = new DateTimeArrayFieldAdapter<TaskAdapter>(TaskContract.Tasks.RDATE,
             TaskContract.Tasks.TZ);
 
     /**
      * Adapter for the EXDATE of a task.
      */
-    public static final DateTimeArrayFieldAdapter<TaskAdapter> EXDATE = new DateTimeArrayFieldAdapter<TaskAdapter>(TaskContract.Tasks.EXDATE,
+    DateTimeArrayFieldAdapter<TaskAdapter> EXDATE = new DateTimeArrayFieldAdapter<TaskAdapter>(TaskContract.Tasks.EXDATE,
             TaskContract.Tasks.TZ);
 
     /**
      * Adapter for the SYNC1 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC1 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC1);
+    BinaryFieldAdapter<TaskAdapter> SYNC1 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC1);
 
     /**
      * Adapter for the SYNC2 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC2 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC2);
+    BinaryFieldAdapter<TaskAdapter> SYNC2 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC2);
 
     /**
      * Adapter for the SYNC3 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC3 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC3);
+    BinaryFieldAdapter<TaskAdapter> SYNC3 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC3);
 
     /**
      * Adapter for the SYNC4 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC4 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC4);
+    BinaryFieldAdapter<TaskAdapter> SYNC4 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC4);
 
     /**
      * Adapter for the SYNC5 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC5 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC5);
+    BinaryFieldAdapter<TaskAdapter> SYNC5 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC5);
 
     /**
      * Adapter for the SYNC6 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC6 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC6);
+    BinaryFieldAdapter<TaskAdapter> SYNC6 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC6);
 
     /**
      * Adapter for the SYNC7 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC7 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC7);
+    BinaryFieldAdapter<TaskAdapter> SYNC7 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC7);
 
     /**
      * Adapter for the SYNC8 field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC8 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC8);
+    BinaryFieldAdapter<TaskAdapter> SYNC8 = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC8);
 
     /**
      * Adapter for the SYNC_VERSION field of a task.
      */
-    public static final BinaryFieldAdapter<TaskAdapter> SYNC_VERSION = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC_VERSION);
+    BinaryFieldAdapter<TaskAdapter> SYNC_VERSION = new BinaryFieldAdapter<TaskAdapter>(TaskContract.Tasks.SYNC_VERSION);
 
     /**
      * Adapter for the SYNC_ID field of a task.
      */
-    public static final StringFieldAdapter<TaskAdapter> SYNC_ID = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks._SYNC_ID);
+    StringFieldAdapter<TaskAdapter> SYNC_ID = new StringFieldAdapter<TaskAdapter>(TaskContract.Tasks._SYNC_ID);
 
     /**
      * Adapter for the due date of a task instance.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> INSTANCE_DUE = new DateTimeFieldAdapter<TaskAdapter>(Instances.INSTANCE_DUE, Tasks.TZ,
+    DateTimeFieldAdapter<TaskAdapter> INSTANCE_DUE = new DateTimeFieldAdapter<TaskAdapter>(Instances.INSTANCE_DUE, Tasks.TZ,
             Tasks.IS_ALLDAY);
 
     /**
      * Adapter for the start date of a task instance.
      */
-    public final static DateTimeFieldAdapter<TaskAdapter> INSTANCE_START = new DateTimeFieldAdapter<TaskAdapter>(Instances.INSTANCE_START, Tasks.TZ,
+    DateTimeFieldAdapter<TaskAdapter> INSTANCE_START = new DateTimeFieldAdapter<TaskAdapter>(Instances.INSTANCE_START, Tasks.TZ,
             Tasks.IS_ALLDAY);
 
     /**
@@ -320,7 +325,7 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
      *
      * @return <code>true</code> if the task is recurring, <code>false</code> otherwise.
      */
-    public boolean isRecurring();
+    boolean isRecurring();
 
     /**
      * Returns whether any value that's relevant for recurrence has been modified thought this adapter. This returns true if any of
@@ -329,7 +334,7 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
      *
      * @return <code>true</code> if the recurrence set has changed, <code>false</code> otherwise.
      */
-    public boolean recurrenceUpdated();
+    boolean recurrenceUpdated();
 
     /***
      * Creates a {@link TaskAdapter} for a new task initialized with the values of this task (except for _ID).
@@ -337,5 +342,5 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
      * @return A new task having the same values.
      */
     @Override
-    public TaskAdapter duplicate();
+    TaskAdapter duplicate();
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
@@ -19,6 +19,7 @@ package org.dmfs.provider.tasks.model;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
 import org.dmfs.provider.tasks.model.adapters.BinaryFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.BooleanFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.DateTimeArrayFieldAdapter;
@@ -232,9 +233,9 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
     BooleanFieldAdapter<TaskAdapter> HAS_ALARMS = new BooleanFieldAdapter<TaskAdapter>(TaskContract.Tasks.HAS_ALARMS);
 
     /**
-     * Adapter for the {@link TaskContract.Tasks#INSTANCES_STALE} flag of a task.
+     * Adapter for the {@link TaskDatabaseHelper.TaskTableColumns#INSTANCES_STALE} flag of a task.
      */
-    BooleanFieldAdapter<TaskAdapter> INSTANCES_STALE = new BooleanFieldAdapter<>(Tasks.INSTANCES_STALE);
+    BooleanFieldAdapter<TaskAdapter> INSTANCES_STALE = new BooleanFieldAdapter<>(TaskDatabaseHelper.TaskTableColumns.INSTANCES_STALE);
 
     /**
      * Adapter for the HAS_PROPERTIES flag of a task.

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
@@ -18,18 +18,12 @@ package org.dmfs.provider.tasks.processors.tasks;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import android.net.Uri;
 
-import org.dmfs.provider.tasks.TaskDatabaseHelper;
 import org.dmfs.provider.tasks.model.TaskAdapter;
 import org.dmfs.provider.tasks.model.adapters.BooleanFieldAdapter;
+import org.dmfs.provider.tasks.model.adapters.IntegerFieldAdapter;
 import org.dmfs.provider.tasks.processors.EntityProcessor;
-import org.dmfs.rfc5545.DateTime;
-import org.dmfs.rfc5545.Duration;
 import org.dmfs.tasks.contract.TaskContract;
-
-import java.sql.RowId;
-import java.util.TimeZone;
 
 
 /**
@@ -74,30 +68,21 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
     @Override
     public TaskAdapter insert(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
     {
-        TaskAdapter result = mDelegate.insert(db, task, isSyncAdapter);
-        createInstances(db, result);
-        return result;
+        // new tasks have invalid instances by default
+        return mDelegate.insert(db, task, isSyncAdapter);
     }
 
 
     @Override
     public TaskAdapter update(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
     {
-        if (task.isUpdated(UPDATE_REQUESTED))
+        if (task.isUpdated(UPDATE_REQUESTED) || task.isUpdated(TaskAdapter.DTSTART) || task.isUpdated(TaskAdapter.DUE) || task.isUpdated(TaskAdapter.DURATION))
         {
-            task.setState(UPDATE_REQUESTED, task.valueOf(UPDATE_REQUESTED));
             task.unset(UPDATE_REQUESTED);
+            // mark this task as "stale"
+            task.set(new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.INSTANCES_STALE), 1);
         }
-        TaskAdapter result = mDelegate.update(db, task, isSyncAdapter);
-
-        if (!result.isUpdated(TaskAdapter.DTSTART) && !result.isUpdated(TaskAdapter.DUE) && !result.isUpdated(TaskAdapter.DURATION)
-                && !result.getState(UPDATE_REQUESTED))
-        {
-            // date values didn't change and update not requested
-            return result;
-        }
-        updateInstances(db, result);
-        return result;
+        return mDelegate.update(db, task, isSyncAdapter);
     }
 
 
@@ -107,109 +92,4 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
         mDelegate.delete(db, entityAdapter, isSyncAdapter);
     }
 
-
-    /**
-     * Create new {@link ContentValues} for insertion into the instances table.
-     *
-     * @param task
-     *         The {@link TaskAdapter} of the task that's about to be inserted.
-     *
-     * @return {@link ContentValues} of the instance of this task.
-     */
-    private ContentValues generateInstanceValues(TaskAdapter task)
-    {
-        ContentValues instanceValues = new ContentValues();
-
-        // get the relevant values from values
-        DateTime dtstart = task.valueOf(TaskAdapter.DTSTART);
-        DateTime due = task.valueOf(TaskAdapter.DUE);
-        Duration duration = task.valueOf(TaskAdapter.DURATION);
-
-        TimeZone localTz = TimeZone.getDefault();
-
-        if (dtstart != null)
-        {
-            // copy dtstart as is
-            instanceValues.put(TaskContract.Instances.INSTANCE_START, dtstart.getTimestamp());
-            instanceValues.put(TaskContract.Instances.INSTANCE_START_SORTING,
-                    dtstart.isAllDay() ? dtstart.getInstance() : dtstart.shiftTimeZone(localTz).getInstance());
-        }
-        else
-        {
-            instanceValues.putNull(TaskContract.Instances.INSTANCE_START);
-            instanceValues.putNull(TaskContract.Instances.INSTANCE_START_SORTING);
-        }
-
-        if (due != null)
-        {
-            // copy due and calculate the actual duration, if any
-            instanceValues.put(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp());
-            instanceValues.put(TaskContract.Instances.INSTANCE_DUE_SORTING, due.isAllDay() ? due.getInstance() : due.shiftTimeZone(localTz).getInstance());
-            if (dtstart != null)
-            {
-                instanceValues.put(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - dtstart.getTimestamp());
-            }
-            else
-            {
-                instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
-            }
-        }
-        else if (duration != null)
-        {
-            if (dtstart != null)
-            {
-                // calculate the actual due value from dtstart and the duration string
-                due = dtstart.addDuration(duration);
-                instanceValues.put(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp());
-                instanceValues.put(TaskContract.Instances.INSTANCE_DUE_SORTING, due.isAllDay() ? due.getInstance() : due.shiftTimeZone(localTz).getInstance());
-                instanceValues.put(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - dtstart.getTimestamp());
-            }
-            else
-            {
-                // this case should be filtered by TaskValidatorProcessor, since setting a DURATION without DTSTART is invalid
-                instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
-                instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE);
-                instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE_SORTING);
-            }
-        }
-        else
-        {
-            instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
-            instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE);
-            instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE_SORTING);
-        }
-        return instanceValues;
-    }
-
-
-    /**
-     * Creates new instances for the given task {@link ContentValues}.
-     * <p>
-     * TODO: expand recurrence
-     * </p>
-     *
-     * @param uri
-     *         The {@link Uri} used when inserting the task.
-     * @param values
-     *         The {@link ContentValues} of the task.
-     * @param rowId
-     *         The new {@link RowId} of the task.
-     */
-    private void createInstances(SQLiteDatabase db, TaskAdapter task)
-    {
-        ContentValues instanceValues = generateInstanceValues(task);
-
-        // set rowID of current Task
-        instanceValues.put(TaskContract.Instances.TASK_ID, task.id());
-
-        db.insert(TaskDatabaseHelper.Tables.INSTANCES, null, instanceValues);
-    }
-
-
-    private void updateInstances(SQLiteDatabase db, TaskAdapter task)
-    {
-        ContentValues instanceValues = generateInstanceValues(task);
-
-        db.update(TaskDatabaseHelper.Tables.INSTANCES, instanceValues, TaskContract.Instances.TASK_ID + " = " + task.id(), null);
-    }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
@@ -21,9 +21,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.dmfs.provider.tasks.model.TaskAdapter;
 import org.dmfs.provider.tasks.model.adapters.BooleanFieldAdapter;
-import org.dmfs.provider.tasks.model.adapters.IntegerFieldAdapter;
 import org.dmfs.provider.tasks.processors.EntityProcessor;
-import org.dmfs.tasks.contract.TaskContract;
 
 
 /**
@@ -80,7 +78,7 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
         {
             task.unset(UPDATE_REQUESTED);
             // mark this task as "stale"
-            task.set(new IntegerFieldAdapter<TaskAdapter>(TaskContract.Tasks.INSTANCES_STALE), 1);
+            task.set(TaskAdapter.INSTANCES_STALE, true);
         }
         return mDelegate.update(db, task, isSyncAdapter);
     }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
@@ -181,6 +181,12 @@ public final class Validating implements EntityProcessor<TaskAdapter>
             throw new IllegalArgumentException("modification of HAS_ALARMS is not allowed");
         }
 
+        // INSTANCES_STALE is for internal purposes and not meant to be modified
+        if (task.isUpdated(TaskAdapter.INSTANCES_STALE))
+        {
+            throw new IllegalArgumentException("modification of INSTANCES_VOID is not allowed");
+        }
+
         // only sync adapters are allowed to set modification time
         if (!isSyncAdapter && task.isUpdated(TaskAdapter.LAST_MODIFIED))
         {

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/TransactionEndTask.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/TransactionEndTask.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.transactionendtasks;
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+/**
+ * A task to be executed at the end of a transaction, after all operations have been applied and right before it's marked successful.
+ *
+ * @author Marten Gajda
+ */
+public interface TransactionEndTask
+{
+    void execute(SQLiteDatabase database);
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/UpdateInstancesTask.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/UpdateInstancesTask.java
@@ -33,7 +33,7 @@ import java.util.TimeZone;
 
 /**
  * A {@link TransactionEndTask} which creates/updates the instances of all tasks which have been flagged as stale.
- *
+ * <p>
  * TODO: handle recurrence
  *
  * @author Marten Gajda
@@ -47,7 +47,7 @@ public final class UpdateInstancesTask implements TransactionEndTask
         Cursor staleInstances = database.query(
                 TaskDatabaseHelper.Tables.TASKS,
                 null,
-                String.format(Locale.ENGLISH, "%s = 1 ", TaskContract.Tasks.INSTANCES_STALE),
+                String.format(Locale.ENGLISH, "%s = 1 ", TaskDatabaseHelper.TaskTableColumns.INSTANCES_STALE),
                 null,
                 null,
                 null,
@@ -56,7 +56,7 @@ public final class UpdateInstancesTask implements TransactionEndTask
         try
         {
             ContentValues clearInstanceVoid = new ContentValues(1);
-            clearInstanceVoid.put(TaskContract.Tasks.INSTANCES_STALE, 0);
+            TaskAdapter.INSTANCES_STALE.setIn(clearInstanceVoid, false);
             while (staleInstances.moveToNext())
             {
                 TaskAdapter task = new CursorContentValuesTaskAdapter(staleInstances, new ContentValues());

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/UpdateInstancesTask.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/transactionendtasks/UpdateInstancesTask.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.transactionendtasks;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.CursorContentValuesTaskAdapter;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
+import org.dmfs.tasks.contract.TaskContract;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+
+/**
+ * A {@link TransactionEndTask} which creates/updates the instances of all tasks which have been flagged as stale.
+ *
+ * TODO: handle recurrence
+ *
+ * @author Marten Gajda
+ */
+public final class UpdateInstancesTask implements TransactionEndTask
+{
+    @Override
+    public void execute(SQLiteDatabase database)
+    {
+        // read all tasks with stale instances
+        Cursor staleInstances = database.query(
+                TaskDatabaseHelper.Tables.TASKS,
+                null,
+                String.format(Locale.ENGLISH, "%s = 1 ", TaskContract.Tasks.INSTANCES_STALE),
+                null,
+                null,
+                null,
+                null);
+
+        try
+        {
+            ContentValues clearInstanceVoid = new ContentValues(1);
+            clearInstanceVoid.put(TaskContract.Tasks.INSTANCES_STALE, 0);
+            while (staleInstances.moveToNext())
+            {
+                TaskAdapter task = new CursorContentValuesTaskAdapter(staleInstances, new ContentValues());
+                ContentValues instanceValues = generateInstanceValues(task);
+                // try updating any existing instance
+                if (database.update(TaskDatabaseHelper.Tables.INSTANCES, instanceValues,
+                        String.format(Locale.ENGLISH, "%s = %d", TaskContract.Instances.TASK_ID, task.id()), null) == 0)
+                {
+                    // if no instances were updated, insert a new one
+                    instanceValues.put(TaskContract.Instances.TASK_ID, task.id());
+                    database.insert(TaskDatabaseHelper.Tables.INSTANCES, "", instanceValues);
+                }
+
+                // wipe the stale instances flag of the task
+                database.update(TaskDatabaseHelper.Tables.TASKS, clearInstanceVoid, String.format(Locale.ENGLISH, "%s = %d", TaskContract.Tasks._ID, task.id()),
+                        null);
+            }
+        }
+        finally
+        {
+            staleInstances.close();
+        }
+    }
+
+
+    /**
+     * Create new {@link ContentValues} for insertion into the instances table.
+     *
+     * @param task
+     *         The {@link TaskAdapter} of the task that's about to be inserted.
+     *
+     * @return {@link ContentValues} of the instance of this task.
+     */
+    private ContentValues generateInstanceValues(TaskAdapter task)
+    {
+        ContentValues instanceValues = new ContentValues();
+
+        // get the relevant values from values
+        DateTime dtstart = task.valueOf(TaskAdapter.DTSTART);
+        DateTime due = task.valueOf(TaskAdapter.DUE);
+        Duration duration = task.valueOf(TaskAdapter.DURATION);
+
+        TimeZone localTz = TimeZone.getDefault();
+
+        if (dtstart != null)
+        {
+            // copy dtstart as is
+            instanceValues.put(TaskContract.Instances.INSTANCE_START, dtstart.getTimestamp());
+            instanceValues.put(TaskContract.Instances.INSTANCE_START_SORTING,
+                    dtstart.isAllDay() ? dtstart.getInstance() : dtstart.shiftTimeZone(localTz).getInstance());
+        }
+        else
+        {
+            instanceValues.putNull(TaskContract.Instances.INSTANCE_START);
+            instanceValues.putNull(TaskContract.Instances.INSTANCE_START_SORTING);
+        }
+
+        if (due != null)
+        {
+            // copy due and calculate the actual duration, if any
+            instanceValues.put(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp());
+            instanceValues.put(TaskContract.Instances.INSTANCE_DUE_SORTING, due.isAllDay() ? due.getInstance() : due.shiftTimeZone(localTz).getInstance());
+            if (dtstart != null)
+            {
+                instanceValues.put(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - dtstart.getTimestamp());
+            }
+            else
+            {
+                instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
+            }
+        }
+        else if (duration != null)
+        {
+            if (dtstart != null)
+            {
+                // calculate the actual due value from dtstart and the duration string
+                due = dtstart.addDuration(duration);
+                instanceValues.put(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp());
+                instanceValues.put(TaskContract.Instances.INSTANCE_DUE_SORTING, due.isAllDay() ? due.getInstance() : due.shiftTimeZone(localTz).getInstance());
+                instanceValues.put(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - dtstart.getTimestamp());
+            }
+            else
+            {
+                // this case should be filtered by TaskValidatorProcessor, since setting a DURATION without DTSTART is invalid
+                instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
+                instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE);
+                instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE_SORTING);
+            }
+        }
+        else
+        {
+            instanceValues.putNull(TaskContract.Instances.INSTANCE_DURATION);
+            instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE);
+            instanceValues.putNull(TaskContract.Instances.INSTANCE_DUE_SORTING);
+        }
+        return instanceValues;
+    }
+}


### PR DESCRIPTION
TaskInstancesProcessor now only sets an instance_stale flag when appropriate. Instances are created after the batch has been processed.
UpdateInstancesTask doesn't handle recurrence yet. That's a different story.