### PR TITLE
Fix selected list font color on edit screen. #526

### DIFF
--- a/opentasks/src/main/res/layout/list_spinner_item_selected.xml
+++ b/opentasks/src/main/res/layout/list_spinner_item_selected.xml
@@ -12,7 +12,8 @@
             android:layout_height="match_parent"
             android:ellipsize="end"
             android:singleLine="true"
-            android:textAppearance="@android:style/TextAppearance.Medium"></TextView>
+            android:textColor="@android:color/white"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
 
     <TextView
             android:id="@+id/task_list_account_name"
@@ -20,6 +21,6 @@
             android:layout_height="match_parent"
             android:ellipsize="end"
             android:singleLine="true"
-            android:textColor="#a0ffffff"></TextView>
+            android:textColor="#a0ffffff"/>
 
 </LinearLayout>


### PR DESCRIPTION
Note, that I tried it with the inverse style as well:
```
@style/TextAppearance.AppCompat.Medium.Inverse
```
and that made white text on Android 7 but strangely it was black on Android 6. So I just set the color to white explicitly.