### PR TITLE
Introduce operations on Instances, implements #464

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
 
 script:
   - android list target
-  - ./gradlew connectedAndroidTest
+  - ./gradlew check connectedAndroidTest

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractInstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractInstanceAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.model;
+
+import android.content.ContentUris;
+import android.net.Uri;
+
+import org.dmfs.tasks.contract.TaskContract;
+
+
+/**
+ * An abstract implementation of a {@link InstanceAdapter} to server as the base for more concrete adapters.
+ *
+ * @author Marten Gajda <marten@dmfs.org>
+ */
+public abstract class AbstractInstanceAdapter implements InstanceAdapter
+{
+    @Override
+    public final Uri uri(String authority)
+    {
+        return ContentUris.withAppendedId(TaskContract.Tasks.getContentUri(authority), id());
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractInstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractInstanceAdapter.java
@@ -32,6 +32,6 @@ public abstract class AbstractInstanceAdapter implements InstanceAdapter
     @Override
     public final Uri uri(String authority)
     {
-        return ContentUris.withAppendedId(TaskContract.Tasks.getContentUri(authority), id());
+        return ContentUris.withAppendedId(TaskContract.Instances.getContentUri(authority), id());
     }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/ContentValuesInstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/ContentValuesInstanceAdapter.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.model;
+
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.adapters.FieldAdapter;
+import org.dmfs.tasks.contract.TaskContract;
+
+
+/**
+ * A {@link TaskAdapter} for tasks that are stored in a {@link ContentValues}.
+ *
+ * @author Marten Gajda <marten@dmfs.org>
+ */
+public class ContentValuesInstanceAdapter extends AbstractInstanceAdapter
+{
+    private long mId;
+    private final ContentValues mValues;
+
+
+    public ContentValuesInstanceAdapter(ContentValues values)
+    {
+        this(-1L, values);
+    }
+
+
+    public ContentValuesInstanceAdapter(long id, ContentValues values)
+    {
+        mId = id;
+        mValues = values;
+    }
+
+
+    @Override
+    public long id()
+    {
+        return mId;
+    }
+
+
+    @Override
+    public <T> T valueOf(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        return fieldAdapter.getFrom(mValues);
+    }
+
+
+    @Override
+    public <T> T oldValueOf(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        return null;
+    }
+
+
+    @Override
+    public <T> boolean isUpdated(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        return fieldAdapter.isSetIn(mValues);
+    }
+
+
+    @Override
+    public boolean isWriteable()
+    {
+        return true;
+    }
+
+
+    @Override
+    public boolean hasUpdates()
+    {
+        return mValues.size() > 0;
+    }
+
+
+    @Override
+    public <T> void set(FieldAdapter<T, InstanceAdapter> fieldAdapter, T value) throws IllegalStateException
+    {
+        fieldAdapter.setIn(mValues, value);
+    }
+
+
+    @Override
+    public <T> void unset(FieldAdapter<T, InstanceAdapter> fieldAdapter) throws IllegalStateException
+    {
+        fieldAdapter.removeFrom(mValues);
+    }
+
+
+    @Override
+    public int commit(SQLiteDatabase db)
+    {
+        if (mValues.size() == 0)
+        {
+            return 0;
+        }
+
+        if (mId < 0)
+        {
+            mId = db.insert(TaskDatabaseHelper.Tables.TASKS, null, mValues);
+            return mId > 0 ? 1 : 0;
+        }
+        else
+        {
+            return db.update(TaskDatabaseHelper.Tables.TASKS, mValues, TaskContract.TaskColumns._ID + "=" + mId, null);
+        }
+    }
+
+
+    @Override
+    public <T> T getState(FieldAdapter<T, InstanceAdapter> stateFieldAdater)
+    {
+        return null;
+    }
+
+
+    @Override
+    public <T> void setState(FieldAdapter<T, InstanceAdapter> stateFieldAdater, T value)
+    {
+
+    }
+
+
+    @Override
+    public InstanceAdapter duplicate()
+    {
+        return new ContentValuesInstanceAdapter(new ContentValues(mValues));
+    }
+
+
+    @Override
+    public TaskAdapter taskAdapter()
+    {
+        // make sure we remove any instance fields
+        ContentValues values = new ContentValues(mValues);
+        values.remove(TaskContract.Instances.INSTANCE_START);
+        values.remove(TaskContract.Instances.INSTANCE_START_SORTING);
+        values.remove(TaskContract.Instances.INSTANCE_DUE);
+        values.remove(TaskContract.Instances.INSTANCE_DUE_SORTING);
+        values.remove(TaskContract.Instances.INSTANCE_DURATION);
+        values.remove(TaskContract.Instances.INSTANCE_ORIGINAL_TIME);
+        values.remove(TaskContract.Instances.TASK_ID);
+        values.remove(TaskContract.Instances.DISTANCE_FROM_CURRENT);
+        values.remove("_id:1");
+
+        return new ContentValuesTaskAdapter(values);
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesInstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesInstanceAdapter.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.model;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.adapters.FieldAdapter;
+import org.dmfs.tasks.contract.TaskContract;
+
+
+/**
+ * An {@link InstanceAdapter} that adapts a {@link Cursor} and a {@link ContentValues} instance. All changes are written to the {@link ContentValues} and can be
+ * stored in the database with {@link #commit(SQLiteDatabase)}.
+ *
+ * @author Marten Gajda <marten@dmfs.org>
+ */
+public class CursorContentValuesInstanceAdapter extends AbstractInstanceAdapter
+{
+    private final long mId;
+    private final Cursor mCursor;
+    private final ContentValues mValues;
+
+
+    public CursorContentValuesInstanceAdapter(Cursor cursor, ContentValues values)
+    {
+        if (cursor == null && !_ID.existsIn(values))
+        {
+            mId = -1L;
+        }
+        else
+        {
+            mId = _ID.getFrom(cursor);
+        }
+        mCursor = cursor;
+        mValues = values;
+    }
+
+
+    public CursorContentValuesInstanceAdapter(long id, Cursor cursor, ContentValues values)
+    {
+        mId = id;
+        mCursor = cursor;
+        mValues = values;
+    }
+
+
+    @Override
+    public long id()
+    {
+        return mId;
+    }
+
+
+    @Override
+    public <T> T valueOf(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        if (mValues == null)
+        {
+            return fieldAdapter.getFrom(mCursor);
+        }
+        return fieldAdapter.getFrom(mCursor, mValues);
+    }
+
+
+    @Override
+    public <T> T oldValueOf(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        return fieldAdapter.getFrom(mCursor);
+    }
+
+
+    @Override
+    public <T> boolean isUpdated(FieldAdapter<T, InstanceAdapter> fieldAdapter)
+    {
+        return mValues != null && fieldAdapter.isSetIn(mValues);
+    }
+
+
+    @Override
+    public boolean isWriteable()
+    {
+        return mValues != null;
+    }
+
+
+    @Override
+    public boolean hasUpdates()
+    {
+        return mValues != null && mValues.size() > 0;
+    }
+
+
+    @Override
+    public <T> void set(FieldAdapter<T, InstanceAdapter> fieldAdapter, T value) throws IllegalStateException
+    {
+        fieldAdapter.setIn(mValues, value);
+    }
+
+
+    @Override
+    public <T> void unset(FieldAdapter<T, InstanceAdapter> fieldAdapter) throws IllegalStateException
+    {
+        fieldAdapter.removeFrom(mValues);
+    }
+
+
+    @Override
+    public int commit(SQLiteDatabase db)
+    {
+        if (mValues.size() == 0)
+        {
+            return 0;
+        }
+
+        return db.update(TaskDatabaseHelper.Tables.TASKS, mValues, TaskContract.TaskColumns._ID + "=" + mId, null);
+    }
+
+
+    @Override
+    public <T> T getState(FieldAdapter<T, InstanceAdapter> stateFieldAdater)
+    {
+        return null;
+    }
+
+
+    @Override
+    public <T> void setState(FieldAdapter<T, InstanceAdapter> stateFieldAdater, T value)
+    {
+
+    }
+
+
+    @Override
+    public InstanceAdapter duplicate()
+    {
+        ContentValues newValues = new ContentValues(mValues);
+
+        // copy all columns (except _ID) that are not in the values yet
+        for (int i = 0, count = mCursor.getColumnCount(); i < count; ++i)
+        {
+            String column = mCursor.getColumnName(i);
+            if (!newValues.containsKey(column) && !TaskContract.Instances._ID.equals(column))
+            {
+                newValues.put(column, mCursor.getString(i));
+            }
+        }
+
+        return new ContentValuesInstanceAdapter(newValues);
+    }
+
+
+    @Override
+    public TaskAdapter taskAdapter()
+    {
+        // make sure we remove any instance fields
+        ContentValues values = new ContentValues(mValues);
+        values.remove(TaskContract.Instances.INSTANCE_START);
+        values.remove(TaskContract.Instances.INSTANCE_START_SORTING);
+        values.remove(TaskContract.Instances.INSTANCE_DUE);
+        values.remove(TaskContract.Instances.INSTANCE_DUE_SORTING);
+        values.remove(TaskContract.Instances.INSTANCE_DURATION);
+        values.remove(TaskContract.Instances.INSTANCE_ORIGINAL_TIME);
+        values.remove(TaskContract.Instances.TASK_ID);
+        values.remove(TaskContract.Instances.DISTANCE_FROM_CURRENT);
+        values.remove("_id:1");
+
+        return new CursorContentValuesTaskAdapter(valueOf(InstanceAdapter.TASK_ID), mCursor, values);
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/InstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/InstanceAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.model;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import org.dmfs.provider.tasks.model.adapters.DateTimeFieldAdapter;
+import org.dmfs.provider.tasks.model.adapters.IntegerFieldAdapter;
+import org.dmfs.provider.tasks.model.adapters.LongFieldAdapter;
+import org.dmfs.tasks.contract.TaskContract.Instances;
+import org.dmfs.tasks.contract.TaskContract.Tasks;
+
+
+/**
+ * Adapter to read instance values from primitive data sets like {@link Cursor}s or {@link ContentValues}s.
+ *
+ * @author Marten Gajda <marten@dmfs.org>
+ */
+public interface InstanceAdapter extends EntityAdapter<InstanceAdapter>
+{
+    /**
+     * Adapter for the row id of a task instance.
+     */
+    LongFieldAdapter<InstanceAdapter> _ID = new LongFieldAdapter<InstanceAdapter>(Instances._ID);
+
+    /**
+     * Adapter for the due date of a task instance.
+     */
+    DateTimeFieldAdapter<InstanceAdapter> INSTANCE_DUE = new DateTimeFieldAdapter<>(Instances.INSTANCE_DUE, Tasks.TZ, Tasks.IS_ALLDAY);
+
+    /**
+     * Adapter for the start date of a task instance.
+     */
+    DateTimeFieldAdapter<InstanceAdapter> INSTANCE_START = new DateTimeFieldAdapter<>(Instances.INSTANCE_START, Tasks.TZ, Tasks.IS_ALLDAY);
+
+    /**
+     * Adapter for the start sorting of a task instance.
+     */
+    LongFieldAdapter<InstanceAdapter> INSTANCE_START_SORTING = new LongFieldAdapter<>(Instances.INSTANCE_START_SORTING);
+
+    /**
+     * Adapter for the due sorting of a task instance.
+     */
+    LongFieldAdapter<InstanceAdapter> INSTANCE_DUE_SORTING = new LongFieldAdapter<>(Instances.INSTANCE_DUE_SORTING);
+
+    /**
+     * Adapter for the original time of a task instance.
+     */
+    DateTimeFieldAdapter<InstanceAdapter> INSTANCE_ORIGINAL_TIME = new DateTimeFieldAdapter<>(Instances.INSTANCE_ORIGINAL_TIME, Tasks.TZ, Tasks.IS_ALLDAY);
+
+    /**
+     * Adapter for the distance of a task instance from the current instance.
+     */
+    IntegerFieldAdapter<InstanceAdapter> DISTANCE_FROM_CURRENT = new IntegerFieldAdapter<>(Instances.DISTANCE_FROM_CURRENT);
+
+    /**
+     * Adapter for the row id of the task.
+     */
+    LongFieldAdapter<InstanceAdapter> TASK_ID = new LongFieldAdapter<InstanceAdapter>(Instances.TASK_ID);
+
+    @Override
+    InstanceAdapter duplicate();
+
+    /**
+     * Returns a {@link TaskAdapter} for the task component of the instanced view.
+     *
+     * @return
+     */
+    TaskAdapter taskAdapter();
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
@@ -72,6 +72,11 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
     public final static StringFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_SYNC_ID = new StringFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_SYNC_ID);
 
     /**
+     * Adapter for the original instance all day flag of a task.
+     */
+    public final static BooleanFieldAdapter<TaskAdapter> ORIGINAL_INSTANCE_ALLDAY = new BooleanFieldAdapter<TaskAdapter>(Tasks.ORIGINAL_INSTANCE_ALLDAY);
+
+    /**
      * Adapter for the all day flag of a task.
      */
     public final static BooleanFieldAdapter<TaskAdapter> IS_ALLDAY = new BooleanFieldAdapter<TaskAdapter>(Tasks.IS_ALLDAY);

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/TaskValueDelegate.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/TaskValueDelegate.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.processors.instances;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.jems.optional.decorators.Mapped;
+import org.dmfs.optional.NullSafe;
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.ContentValuesInstanceAdapter;
+import org.dmfs.provider.tasks.model.CursorContentValuesTaskAdapter;
+import org.dmfs.provider.tasks.model.InstanceAdapter;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.provider.tasks.processors.EntityProcessor;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * An instance {@link EntityProcessor} which delegates to the appropriate task {@link EntityProcessor}.
+ *
+ * @author Marten Gajda
+ */
+public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
+{
+
+    private final EntityProcessor<TaskAdapter> mDelegate;
+
+
+    public TaskValueDelegate(EntityProcessor<TaskAdapter> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public InstanceAdapter insert(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        // for now inserts are just forwarded, but we have to make sure we return an InstanceAdapter which contains the current instance row _ID.
+        // TODO: in case ORIGINAL_INSTANCE_ID refers to a master tasks and ORIGINAL_INSTANCE_TIME is valid we should add an RDATE to it and remove any EXDATE for this
+        // TODO: handle when inserting an instance that already exists, either update the existing override or fail
+        TaskAdapter taskResult = mDelegate.insert(db, entityAdapter.taskAdapter(), false);
+        try (Cursor c = db.query(TaskDatabaseHelper.Tables.INSTANCES, new String[] { TaskContract.Instances._ID },
+                TaskContract.Instances.TASK_ID + "=" + taskResult.id(), null, null, null, null))
+        {
+            // the cursor should contain exactly one row after this operation
+            c.moveToFirst();
+            return new ContentValuesInstanceAdapter(c.getLong(0), new ContentValues());
+        }
+    }
+
+
+    @Override
+    public InstanceAdapter update(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        // if this is the master of a recurring task, we create a new instance or update an existing one for this override, otherwise we just delegate
+        TaskAdapter taskAdapter = entityAdapter.taskAdapter();
+        if (taskAdapter.isRecurring())
+        {
+            // clone the task to create an unsynced override
+            InstanceAdapter newInstanceAdapter = entityAdapter.duplicate();
+            TaskAdapter override = newInstanceAdapter.taskAdapter();
+            override.set(TaskAdapter.ORIGINAL_INSTANCE_ID, entityAdapter.valueOf(InstanceAdapter.TASK_ID));
+            override.set(TaskAdapter.ORIGINAL_INSTANCE_TIME, entityAdapter.valueOf(InstanceAdapter.INSTANCE_ORIGINAL_TIME));
+            override.unset(TaskAdapter.SYNC1);
+            override.unset(TaskAdapter.SYNC2);
+            override.unset(TaskAdapter.SYNC3);
+            override.unset(TaskAdapter.SYNC4);
+            override.unset(TaskAdapter.SYNC5);
+            override.unset(TaskAdapter.SYNC6);
+            override.unset(TaskAdapter.SYNC7);
+            override.unset(TaskAdapter.SYNC8);
+            override.unset(TaskAdapter.SYNC_ID);
+            override.unset(TaskAdapter.SYNC_VERSION);
+            // unset any list and read-only fields
+            override.unset(TaskAdapter.ACCOUNT_NAME);
+            override.unset(TaskAdapter.ACCOUNT_TYPE);
+            override.unset(TaskAdapter.LIST_VISIBLE);
+            override.unset(TaskAdapter.LIST_COLOR);
+            override.unset(TaskAdapter.LIST_NAME);
+            override.unset(TaskAdapter.LIST_ACCESS_LEVEL);
+            override.unset(TaskAdapter.LIST_OWNER);
+            override.unset(TaskAdapter._DELETED);
+            override.unset(TaskAdapter._DIRTY);
+            override.unset(TaskAdapter.IS_NEW);
+            override.unset(TaskAdapter.IS_CLOSED);
+            override.unset(TaskAdapter.HAS_PROPERTIES);
+            override.unset(TaskAdapter.HAS_ALARMS);
+            override.unset(TaskAdapter.ORIGINAL_INSTANCE_SYNC_ID); /* this will be resolved automatically */
+            // also unset any recurrence fields
+            override.unset(TaskAdapter.RRULE);
+            override.unset(TaskAdapter.RDATE);
+            override.unset(TaskAdapter.EXDATE);
+            // finally make sure we update DTSTART and DUE to match the instance values (unless they are set explicitly)
+            if (!taskAdapter.isUpdated(TaskAdapter.DTSTART))
+            {
+                // set DTSTART to the instance start
+                override.set(TaskAdapter.DTSTART, newInstanceAdapter.valueOf(InstanceAdapter.INSTANCE_START));
+            }
+            if (!taskAdapter.isUpdated(TaskAdapter.DUE) && !taskAdapter.isUpdated(TaskAdapter.DURATION))
+            {
+                // set DUE to the effective instance DUE and wipe any duration
+                override.set(TaskAdapter.DUE, newInstanceAdapter.valueOf(InstanceAdapter.INSTANCE_DUE));
+                override.set(TaskAdapter.DURATION, null);
+            }
+            // set the correct original instance allday flag
+            override.set(TaskAdapter.ORIGINAL_INSTANCE_ALLDAY, taskAdapter.valueOf(TaskAdapter.IS_ALLDAY));
+
+            // TODO: if this is the first instance (and maybe no other overrides exist), don't create an override but split the series into two tasks
+            mDelegate.insert(db, override, true /* for now insert as a sync adapter to retain the UID */);
+        }
+        else
+        {
+            // this is a non-recurring task or it's already an override, just delegate the update
+            mDelegate.update(db, taskAdapter, false);
+        }
+        return entityAdapter;
+    }
+
+
+    @Override
+    public void delete(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        // deleted instances are converted to deleted tasks (for non-recurring tasks) or exdates (for recurring tasks).
+        TaskAdapter taskAdapter = entityAdapter.taskAdapter();
+
+        if (taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID) != null)
+        {
+            /* this is an override - we have to:
+             * - mark it deleted
+             * - add an exclusion to the master task
+             *
+             * TODO: if this instance was added by an RDATE, just remove the RDATE
+             * TODO: if this is the first instance, consider moving the recurrence start instead of adding an exdate
+             * TODO: if this is the last instance of a finite task, consider just setting a new recurrence end
+             */
+            long masterTaskId = taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID);
+            DateTime originalTime = entityAdapter.valueOf(InstanceAdapter.INSTANCE_ORIGINAL_TIME);
+
+            // delete the override
+            mDelegate.delete(db, taskAdapter, false);
+
+            // get the master and add an exdate
+            try (Cursor c = db.query(TaskDatabaseHelper.Tables.TASKS, null /* all */, TaskContract.Tasks._ID + "=" + masterTaskId, null, null, null, null))
+            {
+                if (c.moveToFirst())
+                {
+                    TaskAdapter masterTaskAdapter = new CursorContentValuesTaskAdapter(masterTaskId, c, new ContentValues());
+                    addExDate(masterTaskAdapter, originalTime);
+                    mDelegate.update(db, masterTaskAdapter, false);
+                }
+            }
+        }
+        else if (taskAdapter.isRecurring())
+        {
+            // TODO: if this is the first instance, consider moving the recurrence start instead of adding an exdate
+            // TODO: if this is the last instance of a finite task, consider just setting a new recurrence end
+            addExDate(taskAdapter, entityAdapter.valueOf(InstanceAdapter.INSTANCE_ORIGINAL_TIME));
+            mDelegate.update(db, taskAdapter, false);
+        }
+        else
+        {
+            // task is non-recurring, delete it as a non-sync-adapter (effectively setting the _deleted flag)
+            mDelegate.delete(db, taskAdapter, false);
+        }
+    }
+
+
+    private void addExDate(TaskAdapter taskAdapter, DateTime exdate)
+    {
+        List<DateTime> exdates = new Mapped<>(Arrays::asList, new NullSafe<>(taskAdapter.valueOf(TaskAdapter.EXDATE))).value(new ArrayList<>(1));
+        exdates.add(exdate);
+        taskAdapter.set(TaskAdapter.EXDATE, exdates.toArray(new DateTime[exdates.size()]));
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/Validating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/Validating.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.processors.instances;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.model.InstanceAdapter;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.provider.tasks.processors.EntityProcessor;
+
+
+/**
+ * An {@link EntityProcessor} which validates the instance data.
+ *
+ * @author Marten Gajda
+ */
+public final class Validating implements EntityProcessor<InstanceAdapter>
+{
+    private final EntityProcessor<InstanceAdapter> mDelegate;
+
+
+    public Validating(EntityProcessor<InstanceAdapter> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public InstanceAdapter insert(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        validate(entityAdapter, isSyncAdapter);
+        return mDelegate.insert(db, entityAdapter, isSyncAdapter);
+    }
+
+
+    @Override
+    public InstanceAdapter update(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        validate(entityAdapter, isSyncAdapter);
+        return mDelegate.update(db, entityAdapter, isSyncAdapter);
+    }
+
+
+    @Override
+    public void delete(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
+    {
+        mDelegate.delete(db, entityAdapter, isSyncAdapter);
+    }
+
+
+    private void validate(InstanceAdapter instanceAdapter, boolean isSyncAdapter)
+    {
+        if (isSyncAdapter)
+        {
+            throw new UnsupportedOperationException("At present, sync adapters are not expected to write to the instances table.");
+        }
+
+        // actually, no instance value can be changed, the instance table only allows for updating task values
+        if (instanceAdapter.isUpdated(InstanceAdapter._ID) ||
+                instanceAdapter.isUpdated(InstanceAdapter.INSTANCE_START) ||
+                instanceAdapter.isUpdated(InstanceAdapter.INSTANCE_START_SORTING) ||
+                instanceAdapter.isUpdated(InstanceAdapter.INSTANCE_DUE) ||
+                instanceAdapter.isUpdated(InstanceAdapter.INSTANCE_DUE_SORTING) ||
+                instanceAdapter.isUpdated(InstanceAdapter.INSTANCE_ORIGINAL_TIME) ||
+                instanceAdapter.isUpdated(InstanceAdapter.DISTANCE_FROM_CURRENT) ||
+                instanceAdapter.isUpdated(InstanceAdapter.TASK_ID))
+        {
+            throw new IllegalArgumentException("Instance columns are read-only.");
+        }
+
+        TaskAdapter taskAdapter = instanceAdapter.taskAdapter();
+        // By definition, single instances don't have a recurrence set on their own, hence changes to the recurrence fields are not allowed.
+        if (taskAdapter.isUpdated(TaskAdapter.RRULE) ||
+                taskAdapter.isUpdated(TaskAdapter.RDATE) ||
+                taskAdapter.isUpdated(TaskAdapter.EXDATE))
+        {
+            throw new IllegalArgumentException("Recurrence values can not be modified through the instances table.");
+        }
+    }
+}

--- a/opentaskspal/src/main/java/org/dmfs/opentaskstestpal/InstanceTestData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskstestpal/InstanceTestData.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskstestpal;
+
+import android.content.ContentProviderOperation;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.jems.optional.decorators.Mapped;
+import org.dmfs.optional.Optional;
+import org.dmfs.optional.Present;
+import org.dmfs.optional.composite.Zipped;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
+
+import static org.dmfs.optional.Absent.absent;
+
+
+/**
+ * {@link RowData} of the instance table. This sets all values except for {@link TaskContract.Instances#TASK_ID}.
+ * <p>
+ * Note: this is meant for use with an assert operation during tests as the instances table is read only and doesn't allow inserts nor updates.
+ *
+ * @author Marten Gajda
+ */
+public final class InstanceTestData implements RowData<TaskContract.Instances>
+{
+    private final Optional<DateTime> mInstanceStart;
+    private final Optional<DateTime> mInstanceDue;
+    private final Optional<DateTime> mOriginalTime;
+    private final int mDistanceFromCurrent;
+
+
+    public InstanceTestData(int distanceFromCurrent)
+    {
+        this(absent(), absent(), absent(), distanceFromCurrent);
+    }
+
+
+    public InstanceTestData(@NonNull DateTime instanceStart, @NonNull DateTime instanceDue, @NonNull Optional<DateTime> originalTime, int distanceFromCurrent)
+    {
+        this(new Present<>(instanceStart), new Present<>(instanceDue), originalTime, distanceFromCurrent);
+    }
+
+
+    public InstanceTestData(@NonNull Optional<DateTime> instanceStart, @NonNull Optional<DateTime> instanceDue, @NonNull Optional<DateTime> originalTime, int distanceFromCurrent)
+    {
+        mInstanceStart = instanceStart;
+        mInstanceDue = instanceDue;
+        mOriginalTime = originalTime;
+        mDistanceFromCurrent = distanceFromCurrent;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder
+                .withValue(TaskContract.Instances.INSTANCE_START, new Mapped<>(DateTime::getTimestamp, mInstanceStart).value(null))
+                .withValue(TaskContract.Instances.INSTANCE_START_SORTING, new Mapped<>(DateTime::getInstance, mInstanceStart).value(null))
+                .withValue(TaskContract.Instances.INSTANCE_DUE, new Mapped<>(DateTime::getTimestamp, mInstanceDue).value(null))
+                .withValue(TaskContract.Instances.INSTANCE_DUE_SORTING, new Mapped<>(DateTime::getInstance, mInstanceDue).value(null))
+                .withValue(TaskContract.Instances.INSTANCE_DURATION,
+                        new Zipped<>(mInstanceStart, mInstanceDue, (start, due) -> (due.getTimestamp() - start.getTimestamp())).value(null))
+                .withValue(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, mOriginalTime.value(new DateTime(0)).getTimestamp())
+                .withValue(TaskContract.Instances.DISTANCE_FROM_CURRENT, mDistanceFromCurrent);
+    }
+
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskstestpal/InstanceTestDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskstestpal/InstanceTestDataTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskstestpal;
+
+import org.dmfs.optional.Present;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.TimeZone;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.contentvalues.NullValue.withNullValue;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.dmfs.optional.Absent.absent;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class InstanceTestDataTest
+{
+    @Test
+    public void testNoDate() throws Exception
+    {
+        assertThat(new InstanceTestData(5),
+                builds(
+                        withValuesOnly(
+                                withNullValue(TaskContract.Instances.INSTANCE_START),
+                                withNullValue(TaskContract.Instances.INSTANCE_START_SORTING),
+                                withNullValue(TaskContract.Instances.INSTANCE_DUE),
+                                withNullValue(TaskContract.Instances.INSTANCE_DUE_SORTING),
+                                withNullValue(TaskContract.Instances.INSTANCE_DURATION),
+                                containing(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, 0L),
+                                containing(TaskContract.Instances.DISTANCE_FROM_CURRENT, 5)
+                        )
+                ));
+    }
+
+
+    @Test
+    public void testWithDate() throws Exception
+    {
+        DateTime start = DateTime.now();
+        DateTime due = start.addDuration(Duration.parse("P1DT1H"));
+        assertThat(new InstanceTestData(start, due, absent(), 5),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Instances.INSTANCE_START, start.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_START_SORTING, start.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                containing(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_DUE_SORTING, due.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                containing(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - start.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, 0L),
+                                containing(TaskContract.Instances.DISTANCE_FROM_CURRENT, 5)
+                        )
+                ));
+    }
+
+
+    @Test
+    public void testWithDateAndOriginalTime() throws Exception
+    {
+        DateTime start = DateTime.now();
+        DateTime due = start.addDuration(Duration.parse("P1DT1H"));
+        DateTime original = start.addDuration(Duration.parse("P2DT2H"));
+        assertThat(new InstanceTestData(start, due, new Present<>(original), 5),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Instances.INSTANCE_START, start.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_START_SORTING, start.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                containing(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_DUE_SORTING, due.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                containing(TaskContract.Instances.INSTANCE_DURATION, due.getTimestamp() - start.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, original.getTimestamp()),
+                                containing(TaskContract.Instances.DISTANCE_FROM_CURRENT, 5)
+                        )
+                ));
+    }
+
+
+    @Test
+    public void testWithStartDateAndOriginalTime() throws Exception
+    {
+        DateTime start = DateTime.now();
+        DateTime original = start.addDuration(Duration.parse("P2DT2H"));
+        assertThat(new InstanceTestData(new Present<>(start), absent(), new Present<>(original), 5),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Instances.INSTANCE_START, start.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_START_SORTING, start.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                withNullValue(TaskContract.Instances.INSTANCE_DUE),
+                                withNullValue(TaskContract.Instances.INSTANCE_DUE_SORTING),
+                                withNullValue(TaskContract.Instances.INSTANCE_DURATION),
+                                containing(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, original.getTimestamp()),
+                                containing(TaskContract.Instances.DISTANCE_FROM_CURRENT, 5)
+                        )
+                ));
+    }
+
+
+    @Test
+    public void testWithDueDateAndOriginalTime() throws Exception
+    {
+        DateTime due = DateTime.now();
+        DateTime original = due.addDuration(Duration.parse("P2DT2H"));
+        assertThat(new InstanceTestData(absent(), new Present<>(due), new Present<>(original), 5),
+                builds(
+                        withValuesOnly(
+                                withNullValue(TaskContract.Instances.INSTANCE_START),
+                                withNullValue(TaskContract.Instances.INSTANCE_START_SORTING),
+                                containing(TaskContract.Instances.INSTANCE_DUE, due.getTimestamp()),
+                                containing(TaskContract.Instances.INSTANCE_DUE_SORTING, due.swapTimeZone(TimeZone.getDefault()).getInstance()),
+                                withNullValue(TaskContract.Instances.INSTANCE_DURATION),
+                                containing(TaskContract.Instances.INSTANCE_ORIGINAL_TIME, original.getTimestamp()),
+                                containing(TaskContract.Instances.DISTANCE_FROM_CURRENT, 5)
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
This commit adds initial support for operations on the instances table. At present sync adapters are not allowed to write to the instances table, non-sync adapters can only insert or modify task values. Instances table columns are still read-only. This is meant to simplify working with recurrence in the UI. The UI won't have to take special care about creating exceptions. It can simply update or delete individual instances and the provider will take care of creating overrides or ex-dates.