### PR TITLE
Remove the (duplicate) ViewTaskFragment instantiation upon configurat…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
@@ -27,11 +27,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.ColorInt;
 import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.MenuItemCompat.OnActionExpandListener;
 import android.support.v4.view.ViewPager;
@@ -39,7 +37,6 @@ import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.SearchView.OnQueryTextListener;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -63,10 +60,7 @@ import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.utils.BaseActivity;
 import org.dmfs.tasks.utils.ExpandableGroupDescriptor;
 import org.dmfs.tasks.utils.SearchHistoryHelper;
-import org.dmfs.xmlobjects.pull.XmlObjectPullParserException;
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
+import org.dmfs.tasks.utils.Unchecked;
 
 
 /**
@@ -143,12 +137,6 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
     private boolean mAutoExpandSearchView = false;
 
     /**
-     * Indicates that the activity switched to detail view due to rotation.
-     **/
-    @Retain
-    private boolean mSwitchedToDetail = false;
-
-    /**
      * The Uri of the task to display/highlight in the list view.
      **/
     @Retain
@@ -181,8 +169,6 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
      **/
     private boolean mTransientState = false;
 
-    private CollapsingToolbarLayout mToolbarLayout;
-
     private AppBarLayout mAppBarLayout;
 
     private FloatingActionButton mFloatingActionButton;
@@ -191,7 +177,6 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
-        Log.d(TAG, "onCreate called again");
         super.onCreate(savedInstanceState);
 
         // check for single pane activity change
@@ -206,7 +191,6 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
                 Intent viewTaskIntent = new Intent(Intent.ACTION_VIEW);
                 viewTaskIntent.setData(mSelectedTaskUri);
                 startActivity(viewTaskIntent);
-                mSwitchedToDetail = true;
                 mShouldSwitchToDetail = false;
                 mTransientState = true;
             }
@@ -224,53 +208,17 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
         mAuthority = AuthorityUtil.taskAuthority(this);
         mSearchHistoryHelper = new SearchHistoryHelper(this);
 
-        if (findViewById(R.id.task_detail_container) != null)
+        if (findViewById(R.id.task_detail_container) != null  // should be the same as mTwoPane
+                && savedInstanceState == null)
         {
-            // In two-pane mode, list items should be given the
-            // 'activated' state when touched.
-
-            // get list fragment
-            // mTaskListFrag = (TaskListFragment) getSupportFragmentManager().findFragmentById(R.id.task_list);
-            // mTaskListFrag.setListViewScrollbarPositionLeft(true);
-
-            // mTaskListFrag.setActivateOnItemClick(true);
-
             loadTaskDetailFragment(mSelectedTaskUri);
-        }
-        else
-        {
-            FragmentManager fragmentManager = getSupportFragmentManager();
-            Fragment detailFragment = fragmentManager.findFragmentByTag(DETAIL_FRAGMENT_TAG);
-            if (detailFragment != null)
-            {
-                fragmentManager.beginTransaction().remove(detailFragment).commit();
-            }
         }
 
         mGroupingFactories = new AbstractGroupingFactory[] {
                 new ByList(mAuthority, this), new ByDueDate(mAuthority), new ByStartDate(mAuthority),
                 new ByPriority(mAuthority, this), new ByProgress(mAuthority), new BySearch(mAuthority, mSearchHistoryHelper) };
 
-        // set up pager adapter
-        try
-        {
-            mPagerAdapter = new TaskGroupPagerAdapter(getSupportFragmentManager(), mGroupingFactories, this, R.xml.listview_tabs);
-        }
-        catch (XmlPullParserException e)
-        {
-            // TODO Automatisch generierter Erfassungsblock
-            e.printStackTrace();
-        }
-        catch (IOException e)
-        {
-            // TODO Automatisch generierter Erfassungsblock
-            e.printStackTrace();
-        }
-        catch (XmlObjectPullParserException e)
-        {
-            // TODO Automatisch generierter Erfassungsblock
-            e.printStackTrace();
-        }
+        mPagerAdapter = new Unchecked<>(() -> new TaskGroupPagerAdapter(getSupportFragmentManager(), mGroupingFactories, this, R.xml.listview_tabs)).value();
 
         // Setup ViewPager
         mPagerAdapter.setTwoPaneLayout(mTwoPane);
@@ -433,7 +381,6 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
                 Intent detailIntent = new Intent(Intent.ACTION_VIEW);
                 detailIntent.setData(uri);
                 startActivity(detailIntent);
-                mSwitchedToDetail = true;
                 mShouldSwitchToDetail = false;
             }
         }

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/Unchecked.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/Unchecked.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.tasks.utils;
+
+import org.dmfs.jems.single.Single;
+
+
+/**
+ * 'Unchecks' an Exception, i.e. turns a {@link Fragile} into a {@link Single} by rethrowing
+ * the possible {@link Exception} as {@link RuntimeException}.
+ * <p>
+ * Note: This should be obviously used with care only at appropriate places.
+ *
+ * @author Gabor Keszthelyi
+ * @deprecated use it from jems when available
+ */
+@Deprecated
+public final class Unchecked<T> implements Single<T>
+{
+    private final Fragile<T, Exception> mDelegate;
+
+
+    public Unchecked(Fragile<T, Exception> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public T value()
+    {
+        try
+        {
+            return mDelegate.value();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Exception in Unchecked", e);
+        }
+    }
+}


### PR DESCRIPTION
…ion change. Some cleanup in TaskListActivity. #609 

---

I am submitting this now to allow a preliminary check but I will get back to it and have a second look myself as well.

I couldn't reproduce the bug but the stacktrace suggests that it happens after a configuration change / restoration, when the Activity is started and there is already a `ViewTaskFragment` available instantiated by the framework, and we call `loadUri()` on it, and its views are not initialized yet.
It looks like a clear bug that there is no `savedInstanceState == null` check before doing that.

The log I captured for the rotations with the branch `bugs/609-investigation`:
[Tablet-TaskListActivity-Rotation-Fragments.txt](https://github.com/dmfs/opentasks/files/1607603/Tablet-TaskListActivity-Rotation-Fragments.txt)

I've added that null check in this pull request. I've also removed the `else` branch there which would remove the fragment in case of single pane mode - which I don't see how could happen. @dmfs Please check that part if you can see any case when that makes sense. Can a two pane mode transform into a single pane one?

I've also done some clean up around and removed unused fields, and created a `Unchecked(Single)` which adapts from `Fragile` to avoid the need to catch checked exceptions for a constructor call in `onCreate()`.