### PR TITLE
Refactor to always replace task details fragments instead of updating…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
@@ -789,7 +789,9 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
                 activity.finish();
                 if (isNewTask)
                 {
-                    activity.startActivity(new Intent("android.intent.action.VIEW", mTaskUri));
+                    activity.startActivity(
+                            new Intent(Intent.ACTION_VIEW, mTaskUri)
+                                    .putExtra(ViewTaskActivity.EXTRA_COLOR, mListColor));
                 }
             }
             else

--- a/opentasks/src/main/java/org/dmfs/tasks/EmptyTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EmptyTaskFragment.java
@@ -18,11 +18,13 @@ package org.dmfs.tasks;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.dmfs.android.bolts.color.colors.AttributeColor;
+import org.dmfs.android.bolts.color.Color;
+import org.dmfs.android.bolts.color.elementary.ValueColor;
 import org.dmfs.android.retentionmagic.SupportFragment;
 
 
@@ -34,11 +36,22 @@ import org.dmfs.android.retentionmagic.SupportFragment;
  */
 public class EmptyTaskFragment extends SupportFragment
 {
+    private static final String ARG_COLOR = "color";
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    private Color mColor;
+
+
+    /**
+     * @param color
+     *         The color that the toolbars should take. (If available provide the actual task list color, otherwise the primary color.)
+     */
+    public static Fragment newInstance(Color color)
     {
-        return inflater.inflate(R.layout.opentasks_fragment_empty_task, container, false);
+        EmptyTaskFragment fragment = new EmptyTaskFragment();
+        Bundle args = new Bundle();
+        args.putInt(ARG_COLOR, color.argb());
+        fragment.setArguments(args);
+        return fragment;
     }
 
 
@@ -46,10 +59,21 @@ public class EmptyTaskFragment extends SupportFragment
     public void onAttach(Activity activity)
     {
         super.onAttach(activity);
+
+        mColor = new ValueColor(getArguments().getInt(ARG_COLOR));
+
         if (activity instanceof ViewTaskFragment.Callback)
         {
-            ((ViewTaskFragment.Callback) activity)
-                    .updateColor(new AttributeColor(getContext(), R.attr.colorPrimary));
+            ((ViewTaskFragment.Callback) activity).onListColorLoaded(mColor);
         }
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+        View view = inflater.inflate(R.layout.opentasks_fragment_empty_task, container, false);
+        view.findViewById(R.id.empty_task_fragment_appbar).setBackgroundColor(mColor.argb());
+        return view;
     }
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskGroupPagerAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskGroupPagerAdapter.java
@@ -45,7 +45,6 @@ public class TaskGroupPagerAdapter extends FragmentStatePagerAdapter
     @SuppressWarnings("unused")
     private static final String TAG = "TaskGroupPager";
     private final Map<Integer, AbstractGroupingFactory> mGroupingFactories = new HashMap<Integer, AbstractGroupingFactory>(16);
-    private boolean mTwoPaneLayout;
     private final TabConfig mTabConfig;
 
 
@@ -94,7 +93,7 @@ public class TaskGroupPagerAdapter extends FragmentStatePagerAdapter
         int pageId = mTabConfig.getVisibleItem(position).getId();
         AbstractGroupingFactory factory = getGroupingFactoryForId(pageId);
 
-        TaskListFragment fragment = TaskListFragment.newInstance(position, mTwoPaneLayout);
+        TaskListFragment fragment = TaskListFragment.newInstance(position);
         fragment.setExpandableGroupDescriptor(factory.getExpandableGroupDescriptor());
         fragment.setPageId(pageId);
         return fragment;
@@ -156,12 +155,6 @@ public class TaskGroupPagerAdapter extends FragmentStatePagerAdapter
     public int getCount()
     {
         return mTabConfig.visibleSize();
-    }
-
-
-    public void setTwoPaneLayout(boolean twoPane)
-    {
-        mTwoPaneLayout = twoPane;
     }
 
 

--- a/opentasks/src/main/java/org/dmfs/tasks/ViewTaskActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/ViewTaskActivity.java
@@ -23,12 +23,15 @@ import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.MenuItem;
 import android.view.Window;
 import android.view.WindowManager;
 
 import org.dmfs.android.bolts.color.Color;
+import org.dmfs.android.bolts.color.colors.PrimaryColor;
+import org.dmfs.android.bolts.color.elementary.ValueColor;
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.utils.BaseActivity;
 
@@ -42,6 +45,13 @@ import org.dmfs.tasks.utils.BaseActivity;
  */
 public class ViewTaskActivity extends BaseActivity implements ViewTaskFragment.Callback
 {
+
+    /**
+     * The {@link ColorInt} the toolbars should take while loading the task. Optional parameter.
+     * {@link android.graphics.Color#TRANSPARENT} also means absent.
+     */
+    public static final String EXTRA_COLOR = "color";
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -65,7 +75,9 @@ public class ViewTaskActivity extends BaseActivity implements ViewTaskFragment.C
 
         if (savedInstanceState == null)
         {
-            ViewTaskFragment fragment = ViewTaskFragment.newInstance(getIntent().getData());
+            int color = getIntent().getIntExtra(EXTRA_COLOR, 0);
+            ViewTaskFragment fragment = ViewTaskFragment.newInstance(
+                    getIntent().getData(), color != 0 ? new ValueColor(color) : new PrimaryColor(this));
             getSupportFragmentManager().beginTransaction().add(R.id.task_detail_container, fragment).commit();
         }
     }
@@ -109,7 +121,7 @@ public class ViewTaskActivity extends BaseActivity implements ViewTaskFragment.C
 
 
     @Override
-    public void onEditTask(Uri taskUri, ContentSet data)
+    public void onTaskEditRequested(@NonNull Uri taskUri, ContentSet data)
     {
         Intent editTaskIntent = new Intent(Intent.ACTION_EDIT);
         editTaskIntent.setData(taskUri);
@@ -124,11 +136,17 @@ public class ViewTaskActivity extends BaseActivity implements ViewTaskFragment.C
 
 
     @Override
-    public void onDelete(Uri taskUri)
+    public void onTaskDeleted(@NonNull Uri taskUri)
     {
-        /*
-         * The task we're showing has been deleted, just finish.
-         */
+        // The task we're showing has been deleted, just finish.
+        finish();
+    }
+
+
+    @Override
+    public void onTaskCompleted(@NonNull Uri taskUri)
+    {
+        // The task we're showing has been completed, just finish.
         finish();
     }
 
@@ -145,7 +163,7 @@ public class ViewTaskActivity extends BaseActivity implements ViewTaskFragment.C
 
     @SuppressLint("NewApi")
     @Override
-    public void updateColor(Color color)
+    public void onListColorLoaded(@NonNull Color color)
     {
 
         if (VERSION.SDK_INT >= 21)

--- a/opentasks/src/main/res/anim/openttasks_fade_exit.xml
+++ b/opentasks/src/main/res/anim/openttasks_fade_exit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+            android:duration="@android:integer/config_shortAnimTime"
+            android:fromAlpha="1.0"
+            android:toAlpha="0.0"/>
+</set>

--- a/opentasks/src/main/res/layout/fragment_task_view_detail.xml
+++ b/opentasks/src/main/res/layout/fragment_task_view_detail.xml
@@ -48,7 +48,7 @@
                             android:maxLines="3"
                             android:textColor="#ffffffff"
                             android:textColorLink="#d0ffffff"
-                            android:textSize="28sp"></TextView>
+                            android:textSize="28sp"/>
                 </org.dmfs.tasks.widget.TextFieldView>
 
                 <org.dmfs.tasks.widget.TimeFieldView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -73,14 +73,14 @@
                             android:gravity="center_vertical"
                             android:includeFontPadding="false"
                             android:textColor="#ffffffff"
-                            android:textSize="18sp"></TextView>
+                            android:textSize="18sp"/>
 
                     <TextView
                             android:id="@android:id/text2"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginLeft="44dp"
-                            android:textColor="#ffffffff"></TextView>
+                            android:textColor="#ffffffff"/>
 
                     <LinearLayout
                             android:id="@+id/buttons"
@@ -127,8 +127,9 @@
         <LinearLayout
                 android:id="@+id/content"
                 android:layout_width="match_parent"
+                android:background="@android:color/white"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"></LinearLayout>
+                android:orientation="vertical"/>
     </android.support.v4.widget.NestedScrollView>
 
     <android.support.design.widget.FloatingActionButton

--- a/opentasks/src/main/res/layout/opentasks_fragment_empty_task.xml
+++ b/opentasks/src/main/res/layout/opentasks_fragment_empty_task.xml
@@ -3,6 +3,7 @@
         android:layout_height="match_parent">
 
     <android.support.design.widget.AppBarLayout
+            android:id="@+id/empty_task_fragment_appbar"
             style="@style/opentasks_details_appbar"
             android:layout_height="?attr/actionBarSize"/>
 


### PR DESCRIPTION
… them when new task is selected. #624 

---

@dmfs It took some time to get everything correctly working here but it looks good now for me.

There is a field in `TaskListActivity` now to save the last used color, so it can be used while the selected task is loaded. It is useful upon starting up the app and after rotation.

`EmptyTaskFragment` also has a hint color now, so we don't change back the color to primary after a deletion but keep it as it was for that task. 

`ViewTaskFragment` can be further simplified after these changes, I've created a separate ticket for that: https://github.com/dmfs/opentasks/issues/628

This pull request should fix https://github.com/dmfs/opentasks/issues/609 and https://github.com/dmfs/opentasks/issues/525, too.

I've created 3 new classes for reading arguments from `Bundle` here, in order to read the color argument. They help now, but the plan would be to remove and replace them once the full solution from boxed-bolts is available, since that approach is much better and more general.