### PR TITLE
Fix NPE in QuickAddDialogFragment delayed UI update. #629

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
@@ -55,6 +55,7 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
 import org.dmfs.tasks.model.ContentSet;
 import org.dmfs.tasks.model.TaskFieldAdapters;
 import org.dmfs.tasks.utils.RecentlyUsedLists;
+import org.dmfs.tasks.utils.SafeFragmentUiRunnable;
 import org.dmfs.tasks.utils.TasksListCursorSpinnerAdapter;
 
 
@@ -479,23 +480,15 @@ public class QuickAddDialogFragment extends SupportDialogFragment
 
 
     /**
-     * A runnable that closes the dialog.
+     * A {@link Runnable} that closes the dialog.
      */
-    private final Runnable mDismiss = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            dismiss();
-        }
-    };
+    private final Runnable mDismiss = new SafeFragmentUiRunnable(this, this::dismiss);
 
     /**
      * A {@link Runnable} that resets the editor view.
      */
-    private final Runnable mReset = new Runnable()
+    private final Runnable mReset = new SafeFragmentUiRunnable(this, new Runnable()
     {
-
         @Override
         public void run()
         {
@@ -512,5 +505,5 @@ public class QuickAddDialogFragment extends SupportDialogFragment
             InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
             inputMethodManager.showSoftInput(mEditText, 0);
         }
-    };
+    });
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/ViewTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/ViewTaskFragment.java
@@ -64,6 +64,7 @@ import org.dmfs.tasks.notification.TaskNotificationHandler;
 import org.dmfs.tasks.share.ShareIntentFactory;
 import org.dmfs.tasks.utils.ContentValueMapper;
 import org.dmfs.tasks.utils.OnModelLoadedListener;
+import org.dmfs.tasks.utils.SafeFragmentUiRunnable;
 import org.dmfs.tasks.widget.TaskView;
 
 import java.util.Arrays;
@@ -150,18 +151,6 @@ public class ViewTaskFragment extends SupportFragment
     private boolean mShowFloatingActionButton = false;
 
     private boolean mIsTheTitleContainerVisible = true;
-
-    /**
-     * A Runnable that updates the view.
-     */
-    private Runnable mUpdateViewRunnable = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            updateView();
-        }
-    };
 
 
     public interface Callback
@@ -455,7 +444,7 @@ public class ViewTaskFragment extends SupportFragment
     {
         if (mContent != null)
         {
-            mContent.post(mUpdateViewRunnable);
+            mContent.post(new SafeFragmentUiRunnable(this, this::updateView));
         }
     }
 

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/SafeFragmentUiRunnable.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/SafeFragmentUiRunnable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.tasks.utils;
+
+import android.support.v4.app.Fragment;
+
+
+/**
+ * {@link Runnable} control proxy / decorator that only runs the delegate {@link Runnable}
+ * if the provided {@link Fragment} is still added to its activity when {@link #run()} is called.
+ * <p>
+ * Use this to safely execute a delayed UI update in a {@link Fragment}.
+ * <p>
+ * Do not use this when execution has (side)effects which have to be guaranteed.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class SafeFragmentUiRunnable implements Runnable
+{
+    private final Fragment mFragment;
+    private final Runnable mDelegate;
+
+
+    public SafeFragmentUiRunnable(Fragment fragment, Runnable delegate)
+    {
+        mFragment = fragment;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public void run()
+    {
+        if (mFragment.isAdded() && mFragment.getActivity() != null)
+        {
+            mDelegate.run();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a `Runnable` proxy/decorator class to be used in `Fragments` for safely posting a UI update.
Since this is general, I applied it at other places too (not just to fix the NPE in QuickAddDialogFragment),  where I found a `Runnable` in a `Fragment`.

It's called `SafeFragmentUiRunnable` but I also though about `AttachedAware`. But `SafeFragmentUiRunnable` just looks more descriptive at the places of usage. Especially the `Safe` part is reassuring ;)