### PR TITLE
Add spotless Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.diffplug.gradle.spotless' version '3.8.0'
+}
+
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
@@ -28,6 +32,13 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+apply plugin: 'com.diffplug.gradle.spotless'
+spotless {
+    freshmark {
+    }
+    java {
+        target '**/*.java'
+        trimTrailingWhitespace()
+        removeUnusedImports()
+    }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/SQLiteContentProvider.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/SQLiteContentProvider.java
@@ -40,10 +40,10 @@ import java.util.Set;
  */
 /*
  * Changed by marten@dmfs.org:
- * 
+ *
  * removed protected mDb field and replaced it by local fields. There is no reason to store the database if we get a new one for every transaction. Instead we
  * also pass the database to the *InTransaction methods.
- * 
+ *
  * update visibility of class and methods
  */
 abstract class SQLiteContentProvider extends ContentProvider

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/After.java
@@ -10,7 +10,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package org.dmfs.tasks.model.constraints;

--- a/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/constraints/BeforeOrShiftTime.java
@@ -10,7 +10,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package org.dmfs.tasks.model.constraints;


### PR DESCRIPTION
Reduces pull-request bikeshedding by applying consistent code style to
various files. The supplied configuration supports Markdown and Java.
Other languages (such as Kotlin and Groovy) are supported as well.
Include resulting code corrections.

See: https://github.com/diffplug/spotless/tree/master/plugin-gradle