### PR TITLE
Use View.peformHapticFeedback() instead of Vibrator.vibrate() for lis…

### DIFF
--- a/opentasks/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
+++ b/opentasks/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
@@ -36,12 +36,12 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
-import android.os.Vibrator;
 import android.support.annotation.NonNull;
 import android.support.v4.view.MotionEventCompat;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseArray;
+import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -495,15 +495,7 @@ public class DragLinearLayout extends LinearLayout
         draggedItem.onDragStart();
         requestDisallowInterceptTouchEvent(true);
 
-        try
-        {
-            Vibrator vibrator = (Vibrator) getContext().getSystemService(Context.VIBRATOR_SERVICE);
-            vibrator.vibrate(VIBRATION_DURATION);
-        }
-        catch (Exception e)
-        {
-
-        }
+        performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
     }
 
 

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
@@ -294,8 +294,7 @@ public class TaskListFragment extends SupportFragment
             mExpandableListView.expandGroups(mSavedExpandedGroups);
         }
 
-        FlingDetector swiper = new FlingDetector(mExpandableListView, mGroupDescriptor.getElementViewDescriptor().getFlingContentViewId(),
-                getActivity().getApplicationContext());
+        FlingDetector swiper = new FlingDetector(mExpandableListView, mGroupDescriptor.getElementViewDescriptor().getFlingContentViewId());
         swiper.setOnFlingListener(this);
 
         return rootView;

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/FlingDetector.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/FlingDetector.java
@@ -19,10 +19,9 @@ package org.dmfs.tasks.utils;
 import android.animation.Animator;
 import android.animation.Animator.AnimatorListener;
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.graphics.Rect;
 import android.os.Handler;
-import android.os.Vibrator;
+import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -57,7 +56,6 @@ public class FlingDetector implements OnTouchListener, OnScrollListener
     private View mItemChildView;
     private VelocityTracker mVelocityTracker;
     private int mContentViewId;
-    private static Context mContext;
     private static Handler mHandler;
 
     private int mFlingDirection;
@@ -68,8 +66,7 @@ public class FlingDetector implements OnTouchListener, OnScrollListener
         @Override
         public void run()
         {
-            Vibrator vibrator = (Vibrator) mContext.getSystemService(Context.VIBRATOR_SERVICE);
-            vibrator.vibrate(VIBRATION_DURATION);
+            mListView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
 
             // if we don't disallow that, fling doesn't work on some devices
             mListView.requestDisallowInterceptTouchEvent(true);
@@ -165,7 +162,7 @@ public class FlingDetector implements OnTouchListener, OnScrollListener
      */
     public FlingDetector(ListView listview)
     {
-        this(listview, -1, null);
+        this(listview, -1);
     }
 
 
@@ -177,13 +174,12 @@ public class FlingDetector implements OnTouchListener, OnScrollListener
      * @param flingContentViewId
      *         The layout id of the inner content view that is supposed to fling
      */
-    public FlingDetector(ListView listview, int flingContentViewId, Context context)
+    public FlingDetector(ListView listview, int flingContentViewId)
     {
         listview.setOnTouchListener(this);
         listview.setOnScrollListener(this);
         mListView = listview;
         mContentViewId = flingContentViewId;
-        mContext = context;
 
         ViewConfiguration vc = ViewConfiguration.get(listview.getContext());
 


### PR DESCRIPTION
…t item long press and checklist long presses so it is enabled/disabled as per device settings. Remove an unused field in FlingDetector. #191