### PR TITLE
Add QuickSettingsTile for easy task creation

### DIFF
--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -348,6 +348,18 @@
         <service
                 android:name="org.dmfs.tasks.notification.NotificationUpdaterService"
                 android:exported="false"/>
+
+        <service
+            android:name="org.dmfs.tasks.quicksettings.TaskQuickSettingsTile"
+            android:icon="@drawable/content_edit"
+            android:label="@string/quicksettingstile_create"
+            android:description="@string/quicksettingstile_create"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/opentasks/src/main/java/org/dmfs/tasks/quicksettings/TaskQuickSettingsTile.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/quicksettings/TaskQuickSettingsTile.java
@@ -1,0 +1,33 @@
+package org.dmfs.tasks.quicksettings;
+
+import android.content.Intent;
+import android.os.Build;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+import android.support.annotation.RequiresApi;
+
+import org.dmfs.tasks.EditTaskActivity;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class TaskQuickSettingsTile extends TileService {
+
+    @Override
+    public void onClick() {
+        final Intent taskCreateIntent = new Intent(getApplicationContext(), EditTaskActivity.class);
+        taskCreateIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        unlockAndRun(new Runnable() {
+            @Override
+            public void run() {
+                startActivityAndCollapse(taskCreateIntent);
+            }
+        });
+    }
+
+    @Override
+    public void onStartListening() {
+        Tile tile = getQsTile();
+        tile.setState(Tile.STATE_ACTIVE);
+        tile.updateTile();
+    }
+
+}

--- a/opentasks/src/main/res/values/strings.xml
+++ b/opentasks/src/main/res/values/strings.xml
@@ -226,6 +226,9 @@
     <string name="button_add_one_hour">+1 hour</string>
     <string name="button_add_one_day">+1 day</string>
 
+    <!-- Strings for QuickSettingsTile -->
+    <string name="quicksettingstile_create">Create Task</string>
+
     <!-- Dashclock -->
     <string name="dashclock_extension_title">Tasks</string>
     <string name="dashclock_extension_description">Displays information for recent tasks.</string>


### PR DESCRIPTION
This MR adds a simple QuickSettingsTile for OpenTasks, so you are able to create a task from your quick settings on the fly.