### PR TITLE
Always replace task details fragments instead of updating them. #624

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
@@ -100,6 +100,8 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
     public static final String PREFERENCE_LAST_LIST = "pref_last_list_used_for_new_event";
     public static final String PREFERENCE_LAST_ACCOUNT_TYPE = "pref_last_account_type_used_for_new_event";
 
+    public static final String KEY_NEW_TASK = "new_event";
+
     /**
      * A set of values that may affect the recurrence set of a task. If one of these values changes we have to submit all of them.
      */
@@ -784,7 +786,7 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
 
                 mTaskUri = mValues.persist(activity);
 
-                activity.setResult(Activity.RESULT_OK, new Intent().setData(mTaskUri));
+                activity.setResult(Activity.RESULT_OK, new Intent().setData(mTaskUri).putExtra(KEY_NEW_TASK, isNewTask));
                 Toast.makeText(activity, R.string.activity_edit_task_task_saved, Toast.LENGTH_SHORT).show();
                 activity.finish();
                 if (isNewTask)

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
@@ -489,18 +489,17 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
     private void resolveIntentAction(Intent intent)
     {
         // check which task should be selected
-        if (intent.hasExtra(EXTRA_DISPLAY_TASK))
+        if (intent.getBooleanExtra(EXTRA_DISPLAY_TASK, false))
 
         {
             mShouldSwitchToDetail = true;
             mSelectedTaskUri = intent.getData();
         }
 
-        if (intent != null && intent.hasExtra(EXTRA_DISPLAY_TASK) && intent.getBooleanExtra(EXTRA_FORCE_LIST_SELECTION, true) && mTwoPane)
+        if (intent.getBooleanExtra(EXTRA_DISPLAY_TASK, false) && intent.getBooleanExtra(EXTRA_FORCE_LIST_SELECTION, true) && mTwoPane)
         {
             mShouldSwitchToDetail = true;
-            Uri newSelection = intent.getData();
-            mSelectedTaskUriOnLaunch = newSelection;
+            mSelectedTaskUriOnLaunch = intent.getData();
             mShouldSelectTaskListItem = true;
             if (mPagerAdapter != null)
             {
@@ -522,7 +521,7 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
         {
             // Use the same flow to display the new task as if it was opened from the widget
             Intent displayIntent = new Intent(this, TaskListActivity.class);
-            displayIntent.putExtra(TaskListActivity.EXTRA_DISPLAY_TASK, true);
+            displayIntent.putExtra(TaskListActivity.EXTRA_DISPLAY_TASK, !intent.getBooleanExtra(EditTaskFragment.KEY_NEW_TASK, false));
             displayIntent.putExtra(TaskListActivity.EXTRA_FORCE_LIST_SELECTION, true);
             Uri newTaskUri = intent.getData();
             displayIntent.setData(newTaskUri);


### PR DESCRIPTION
Fix rotation issue after creating a task on a handset device.