### PR TITLE
Use color picker dialog. Fixes #590

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@ ext.deps = [
         datetime           : 'org.dmfs:rfc5545-datetime:0.2.4',
         lib_recur          : 'org.dmfs:lib-recur:0.10.1',
         xml_magic          : 'org.dmfs:android-xml-magic:0.1.1',
-        color_picker       : 'com.github.dmfs.color-picker:colorpicker-activity:1.1',
+        color_picker       : 'com.github.dmfs.color-picker:colorpicker:1.1',
         android_carrot     : 'com.github.dmfs.androidcarrot:androidcarrot:13edc04',
         bolts_color        : 'com.github.dmfs.bolts:color-bolts:2b1b95d', // 2b1b95d -> 2017-12-12
         contentpal         : "com.github.dmfs.contentpal:contentpal:$contentpal_version",


### PR DESCRIPTION
This commit switches from using the color picker as an activity via the open intent to using the color picker as a dialog fragment. This means the color picker is fixed now and no external picker can be used. It's not clear if anyone actually did that though.