### PR TITLE
Partially restore 5f4e901, fixes #711

### DIFF
--- a/opentasks/src/main/res/layout/activity_manage_task_list.xml
+++ b/opentasks/src/main/res/layout/activity_manage_task_list.xml
@@ -17,8 +17,7 @@
             android:paddingEnd="16dp"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
-            android:paddingStart="16dp"
-            android:focusable="true">
+            android:paddingStart="16dp">
 
         <TextView
                 style="@style/TextAppearance.AppCompat.Subhead"
@@ -45,8 +44,7 @@
             android:paddingEnd="16dp"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
-            android:paddingStart="16dp"
-            android:focusable="true">
+            android:paddingStart="16dp">
 
         <TextView
                 style="@style/TextAppearance.AppCompat.Subhead"

--- a/opentasks/src/main/res/layout/checklist_field_view.xml
+++ b/opentasks/src/main/res/layout/checklist_field_view.xml
@@ -28,8 +28,7 @@
                 android:layout_marginLeft="-8dp"
                 android:clickable="true"
                 android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:orientation="horizontal">
 
             <ImageView
                     android:id="@+id/drag_handle"

--- a/opentasks/src/main/res/layout/fragment_quick_add_dialog_header.xml
+++ b/opentasks/src/main/res/layout/fragment_quick_add_dialog_header.xml
@@ -30,8 +30,7 @@
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:padding="8dp"
-                android:src="@drawable/content_edit"
-                android:focusable="true"/>
+                android:src="@drawable/content_edit"/>
     </LinearLayout>
 
     <Spinner

--- a/opentasks/src/main/res/layout/opentasks_location_field_view.xml
+++ b/opentasks/src/main/res/layout/opentasks_location_field_view.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <org.dmfs.tasks.widget.LocationFieldView xmlns:android="http://schemas.android.com/apk/res/android"
         android:clickable="true"
-        style="@style/task_widget"
-        android:focusable="true">
+        style="@style/task_widget">
 
     <!-- TODO Touch feedback could be added later (android:background="?android:attr/selectableItemBackground" requires min API 11)-->
 

--- a/opentasks/src/main/res/layout/task_list_group.xml
+++ b/opentasks/src/main/res/layout/task_list_group.xml
@@ -97,8 +97,7 @@
             android:clickable="true"
             android:padding="8dp"
             android:src="@drawable/ic_24_plus_black50"
-            android:visibility="gone"
-            android:focusable="true"/>
+            android:visibility="gone"/>
 
     <View
             android:id="@+id/divider"

--- a/opentasks/src/main/res/layout/task_list_group_single_line.xml
+++ b/opentasks/src/main/res/layout/task_list_group_single_line.xml
@@ -47,8 +47,7 @@
             android:clickable="true"
             android:padding="8dp"
             android:src="@drawable/ic_24_plus_black50"
-            android:visibility="gone"
-            android:focusable="true"/>
+            android:visibility="gone"/>
 
     <View
             android:id="@+id/divider"

--- a/opentasks/src/main/res/layout/visible_task_list_item.xml
+++ b/opentasks/src/main/res/layout/visible_task_list_item.xml
@@ -37,8 +37,7 @@
             android:clickable="true"
             android:padding="12dp"
             android:src="@drawable/ic_24_settings_black50"
-            android:tint="?attr/colorAccent"
-            android:focusable="true"/>
+            android:tint="?attr/colorAccent"/>
 
     <TextView
             android:id="@android:id/text1"


### PR DESCRIPTION
Commit 5f4e901 contains a couple of changes which break the UI in that some elements don't respond to clicks anymore.
In particular the `focusable="true"` attirbute seems to cause these issues. For now We simply revert the addition of these attributes.
In another story we should address the issue and fix the layout.