### PR TITLE
Fix wrong ID being used. Fixes #723

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
@@ -503,7 +503,7 @@ public class TaskListFragment extends SupportFragment
             }
 
             // TODO For now we get the id of the task, not the instance, once we support recurrence we'll have to change that, use instance URI that time
-            Uri taskUri = ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), (long) TaskFieldAdapters.TASK_ID.get(cursor));
+            Uri taskUri = ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), (long) TaskFieldAdapters.INSTANCE_TASK_ID.get(cursor));
             Color taskListColor = new ValueColor(TaskFieldAdapters.LIST_COLOR.get(cursor));
             mCallbacks.onItemSelected(taskUri, taskListColor, force, mInstancePosition);
         }


### PR DESCRIPTION
In an earlier commit we changed how the lists are loaded. Instead of loading them from the tasks table we now load them from the instances table. This was meant to prepare support for recurring tasks.

Unfortunately we missed on line where we were still using the `_id` column to get the task id (when we should actually use the `task_id` column now). This didn't cause any problem as long as the task id and the instance id where in sync (hence it wasn't an issue while testing). However, under certain circumstances this assumption is no longer true and caused an illegal Task URI to be loaded when clicking a task.

The list now uses the `task_id` column to create the task URI to show.