### PR TITLE
Auto-Determine release channel, implements #725

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags', '--always'
+        commandLine 'git', 'describe', '--tags', '--always', '--dirty'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -95,5 +95,22 @@ dependencies {
 if (project.hasProperty('PLAY_STORE_SERVICE_ACCOUNT_CREDENTIALS')) {
     play {
         serviceAccountCredentials = file(PLAY_STORE_SERVICE_ACCOUNT_CREDENTIALS)
+        // the track is determined automatically by the version number format
+        switch (version){
+            case ~/^(\d+)(\.\d+)*-\d+-[\w\d]+-dirty$/:
+                // work in progress goes to the internal track
+                track = "internal"
+                break
+            case ~/^(\d+)(\.\d+)*-\d+-[\w\d]+$/:
+                // untagged commits go to alpha
+                track = "alpha"
+                break
+            case ~/^(\d+)(\.\d+)*$/:
+                // tagged commits to go beta, from where they get promoted to releases
+                track = "beta"
+                break
+            default:
+                throw new IllegalArgumentException("Unrecognized version format")
+        }
     }
 }


### PR DESCRIPTION
Update the publish configuration to derive the publishing track form the version number.