### PR TITLE
Fix track selection, fixes #747

### DIFF
--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -98,7 +98,7 @@ if (project.hasProperty('PLAY_STORE_SERVICE_ACCOUNT_CREDENTIALS')) {
         serviceAccountCredentials = file(PLAY_STORE_SERVICE_ACCOUNT_CREDENTIALS)
         // the track is determined automatically by the version number format
         switch (version){
-            case ~/^(\d+)(\.\d+)*-\d+-[\w\d]+-dirty$/:
+            case ~/^(\d+)(\.\d+)*(-\d+-[\w\d]+)?-dirty$/:
                 // work in progress goes to the internal track
                 track = "internal"
                 break


### PR DESCRIPTION
The regular expression for the internal track didn't cover a revision descirption like `1.1.16-dirty` which is a release commit with changes.
The proposed fix makes the part between the version number and `-dirty` optional.