### PR TITLE
 fix recursive updateNotification calls 

### DIFF
--- a/opentasks/build.gradle
+++ b/opentasks/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     androidTestImplementation(deps.support_test_rules) {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    compile project(path: ':opentaskspal')
+    implementation project(path: ':opentaskspal')
 }
 
 if (project.hasProperty('PLAY_STORE_SERVICE_ACCOUNT_CREDENTIALS')) {


### PR DESCRIPTION
#749 always updates notifications after transaction.
As updating notificaton queries the database it gets stuck in a loop.

Partly reverted #749 to fix this.