### PR TITLE
Improve FTS performance, fixes #750

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 def support_lib_version = '26.1.0'
-def jems_version = '1.15'
+def jems_version = '1.18'
 def contentpal_version = '9b087b2' // 9b087b2 -> 2017-12-12
 def support_test_runner_version = '0.5'
 

--- a/opentasks-provider/src/main/java/org/dmfs/ngrams/NGramGenerator.java
+++ b/opentasks-provider/src/main/java/org/dmfs/ngrams/NGramGenerator.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.ngrams;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -112,28 +113,15 @@ public final class NGramGenerator
      * @param data
      *         The String to analyze.
      *
-     * @return A {@link Set} containing all N-grams.
+     * @return The {@link Set} containing the N-grams.
      */
     public Set<String> getNgrams(String data)
     {
-        Set<String> result = new HashSet<String>(128);
+        if (data == null)
+        {
+            return Collections.emptySet();
+        }
 
-        return getNgrams(result, data);
-    }
-
-
-    /**
-     * Get all N-grams contained in the given String.
-     *
-     * @param set
-     *         The set to add all the N-grams to, or <code>null</code> to create a new set.
-     * @param data
-     *         The String to analyze.
-     *
-     * @return The {@link Set} containing the N-grams.
-     */
-    public Set<String> getNgrams(Set<String> set, String data)
-    {
         if (mAllLowercase)
         {
             data = data.toLowerCase(mLocale);
@@ -141,10 +129,7 @@ public final class NGramGenerator
 
         String[] words = mReturnNumbers ? SEPARATOR_PATTERN.split(data) : SEPARATOR_PATTERN_NO_NUMBERS.split(data);
 
-        if (set == null)
-        {
-            set = new HashSet<String>(128);
-        }
+        Set<String> set = new HashSet<String>(128);
 
         for (String word : words)
         {

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/Chunked.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/Chunked.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import java.util.Iterator;
+import java.util.Locale;
+
+
+/**
+ * An {@link Iterable} decorator which returns the elements of the decorated {@link Iterable} in chunks of a specific size.
+ *
+ * @author Marten Gajda
+ * @deprecated TODO: move to jems
+ */
+public final class Chunked<T> implements Iterable<Iterable<T>>
+{
+    private final int mChunkSize;
+    private final Iterable<T> mDelegate;
+
+
+    public Chunked(int chunkSize, Iterable<T> delegate)
+    {
+        if (chunkSize <= 0)
+        {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Chunk size must be >0 but was %s", chunkSize));
+        }
+        mChunkSize = chunkSize;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public Iterator<Iterable<T>> iterator()
+    {
+        return new ChunkedIterator<>(mChunkSize, mDelegate.iterator());
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ChunkedIterator.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ChunkedIterator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import org.dmfs.iterators.AbstractBaseIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+
+/**
+ * In {@link Iterator} decorator which returns the elements of the decorated {@link Iterator} in chunks of a specific size.
+ *
+ * @author Marten Gajda
+ * @deprecated TODO: Move to jems.
+ */
+public final class ChunkedIterator<T> extends AbstractBaseIterator<Iterable<T>>
+{
+    private final int mChunkSize;
+    private final Iterator<T> mDelegate;
+
+
+    public ChunkedIterator(int chunkSize, Iterator<T> delegate)
+    {
+        if (chunkSize <= 0)
+        {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Chunk size must be >0 but was %s", chunkSize));
+        }
+        mChunkSize = chunkSize;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mDelegate.hasNext();
+    }
+
+
+    @Override
+    public Iterable<T> next()
+    {
+        List<T> result = new ArrayList<>(mChunkSize);
+        int remaining = mChunkSize;
+        do
+        {
+            result.add(mDelegate.next());
+        } while (mDelegate.hasNext() && --remaining > 0);
+        return result;
+    }
+}

--- a/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ChunkedTest.java
+++ b/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ChunkedTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class ChunkedTest
+{
+    @Test
+    public void test()
+    {
+        // error case, illegal chnuk size
+        assertThat(() -> new Chunked<>(-1, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+        assertThat(() -> new Chunked<>(0, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+
+        // edge case chunk size 1
+        assertThat(new Chunked<>(1, new Seq<>()), is(emptyIterable()));
+        assertThat(new Chunked<>(1, new Seq<>(1)), iteratesTo(iteratesTo(1)));
+        assertThat(new Chunked<>(1, new Seq<>(1, 2, 3)), iteratesTo(iteratesTo(1), iteratesTo(2), iteratesTo(3)));
+
+        // regular case chunk size >1
+        assertThat(new Chunked<>(3, new Seq<>()), is(emptyIterable()));
+        assertThat(new Chunked<>(3, new Seq<>(1)), iteratesTo(iteratesTo(1)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3)), iteratesTo(iteratesTo(1, 2, 3)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6, 7)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6), iteratesTo(7)));
+    }
+}


### PR DESCRIPTION
The previous implementation tried to use the CONFLICT_IGNORE policy when inserting new ngrams and was falling back to a query in case it failed to find the id of the exiting ngram. This was very slow because it meant an expensive query for every ngram to insert.

The new solution goes over the existing ngrams and only inserts the ones which don't exist in the database. Similarily the ngram relations table is not cleared for the particular task, instead the existing ngrams are loaded and only new relations are inserted and obsolete relations are removed.