### PR TITLE
Detect state saved before FM commit, fixes #756

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListActivity.java
@@ -455,9 +455,14 @@ public class TaskListActivity extends BaseActivity implements TaskListFragment.C
 
     private void replaceTaskDetailsFragment(@NonNull Fragment fragment)
     {
-        getSupportFragmentManager().beginTransaction()
-                .setCustomAnimations(0, R.anim.openttasks_fade_exit, 0, 0)
-                .replace(R.id.task_detail_container, fragment, DETAILS_FRAGMENT_TAG).commit();
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        // only change state if the state has not been saved yet, otherwise just drop it
+        if (!fragmentManager.isStateSaved())
+        {
+            fragmentManager.beginTransaction()
+                    .setCustomAnimations(0, R.anim.openttasks_fade_exit, 0, 0)
+                    .replace(R.id.task_detail_container, fragment, DETAILS_FRAGMENT_TAG).commit();
+        }
     }
 
 


### PR DESCRIPTION
Under certain conditions the task details fragment was about to be replaced after the fragment manager already saved its state. This caused a crash. This change checks whether the state has already been saved before committing the transaction.