### PR TITLE
Always create DetailView, fixes #755

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/ViewTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/ViewTaskFragment.java
@@ -143,7 +143,7 @@ public class ViewTaskFragment extends SupportFragment
     private Toolbar mToolBar;
     private View mRootView;
 
-    private int mAppBarOffset = 0;
+        private int mAppBarOffset = 0;
 
     private FloatingActionButton mFloatingActionButton;
 
@@ -262,6 +262,8 @@ public class ViewTaskFragment extends SupportFragment
 
         mRootView = inflater.inflate(R.layout.fragment_task_view_detail, container, false);
         mContent = (ViewGroup) mRootView.findViewById(R.id.content);
+        mDetailView = (TaskView) inflater.inflate(R.layout.task_view, mContent, false);
+        mContent.addView(mDetailView);
         mAppBar = (AppBarLayout) mRootView.findViewById(R.id.appbar);
         mToolBar = (Toolbar) mRootView.findViewById(R.id.toolbar);
         mToolBar.setOnMenuItemClickListener(this);


### PR DESCRIPTION
Instead of creating the details view lazily when the task is loaded, we create it in `onCreateView` so it always exist. Hopefully this fixes #755, but since the actual reason is still unclear we can't be sure. In any case the details view needs a refactoring which reduces mutable state and makes it more robust.