### PR TITLE
Add some simple profiling for provider operations. supports #738

### DIFF
--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Searchable.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Searchable.java
@@ -21,6 +21,7 @@ import android.database.sqlite.SQLiteDatabase;
 import org.dmfs.provider.tasks.FTSDatabaseHelper;
 import org.dmfs.provider.tasks.model.TaskAdapter;
 import org.dmfs.provider.tasks.processors.EntityProcessor;
+import org.dmfs.provider.tasks.utils.Profiled;
 
 
 /**
@@ -43,7 +44,7 @@ public final class Searchable implements EntityProcessor<TaskAdapter>
     public TaskAdapter insert(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
     {
         TaskAdapter result = mDelegate.insert(db, task, isSyncAdapter);
-        FTSDatabaseHelper.updateTaskFTSEntries(db, task);
+        new Profiled("InsertFTS").run(() -> FTSDatabaseHelper.updateTaskFTSEntries(db, task));
         return result;
     }
 
@@ -52,7 +53,7 @@ public final class Searchable implements EntityProcessor<TaskAdapter>
     public TaskAdapter update(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
     {
         TaskAdapter result = mDelegate.update(db, task, isSyncAdapter);
-        FTSDatabaseHelper.updateTaskFTSEntries(db, task);
+        new Profiled("UpdateFTS").run(() -> FTSDatabaseHelper.updateTaskFTSEntries(db, task));
         return result;
     }
 
@@ -60,6 +61,6 @@ public final class Searchable implements EntityProcessor<TaskAdapter>
     @Override
     public void delete(SQLiteDatabase db, TaskAdapter entityAdapter, boolean isSyncAdapter)
     {
-        mDelegate.delete(db, entityAdapter, isSyncAdapter);
+        new Profiled("DeleteFTS").run(() -> mDelegate.delete(db, entityAdapter, isSyncAdapter));
     }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/Profiled.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/Profiled.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.util.Log;
+
+import org.dmfs.jems.fragile.Fragile;
+import org.dmfs.jems.single.Single;
+
+import java.util.Locale;
+
+
+/**
+ * A simple class to measure the execution time of a given piece of code.
+ *
+ * @author Marten Gajda
+ */
+public final class Profiled
+{
+    private final String mSubject;
+
+
+    public Profiled(String subject)
+    {
+        mSubject = subject;
+    }
+
+
+    public void run(Runnable runnable)
+    {
+        long start = System.currentTimeMillis();
+        runnable.run();
+        Log.d("Profiled", String.format(Locale.ENGLISH, "Time spent in %s: %d milliseconds", mSubject, System.currentTimeMillis() - start));
+    }
+
+
+    public <V> V run(Single<V> runnable)
+    {
+
+        long start = System.currentTimeMillis();
+        try
+        {
+            return runnable.value();
+        }
+        finally
+        {
+            Log.d("Profiled", String.format(Locale.ENGLISH, "Time spent in %s: %d milliseconds", mSubject, System.currentTimeMillis() - start));
+        }
+    }
+
+
+    public <V, E extends Exception> V run(Fragile<V, E> runnable) throws E
+    {
+
+        long start = System.currentTimeMillis();
+        try
+        {
+            return runnable.value();
+        }
+        finally
+        {
+            Log.d("Profiled", String.format(Locale.ENGLISH, "Time spent in %s: %d milliseconds", mSubject, System.currentTimeMillis() - start));
+        }
+    }
+
+}


### PR DESCRIPTION
In order to evaluate the provider performance and its impact on the UX this commit adds some simple profiling statments which measure the execution time of certain operations and write them to logcat.
Hopefully this helps a but to detect slow operations and bottlenecks.