### PR TITLE
Add VERSION column, implements #778

### DIFF
--- a/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
+++ b/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
@@ -472,6 +472,18 @@ public final class TaskContract
         String _ID = "_id";
 
         /**
+         * The local version number of this task. The only guarantee about the value is, it's incremented whenever the task changes (this includes any
+         * changes applied by sync adapters).
+         * <p>
+         * Note, there is no guarantee about how much it's incremented other than by at least 1.
+         * <p>
+         * Value: Integer
+         * <p>
+         * read-only
+         */
+        String VERSION = "version";
+
+        /**
          * The id of the list this task belongs to. This value is <strong>write-once</strong> and must not be <code>null</code>.
          * <p>
          * Value: Integer

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/TaskAdapter.java
@@ -21,8 +21,8 @@ import android.database.Cursor;
 
 import org.dmfs.provider.tasks.model.adapters.BinaryFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.BooleanFieldAdapter;
-import org.dmfs.provider.tasks.model.adapters.DateTimeIterableFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.DateTimeFieldAdapter;
+import org.dmfs.provider.tasks.model.adapters.DateTimeIterableFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.DurationFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.IntegerFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.LongFieldAdapter;
@@ -45,6 +45,11 @@ public interface TaskAdapter extends EntityAdapter<TaskAdapter>
      * Adapter for the row id of a task.
      */
     LongFieldAdapter<TaskAdapter> _ID = new LongFieldAdapter<TaskAdapter>(Tasks._ID);
+
+    /**
+     * Adapter for the version of a task.
+     */
+    LongFieldAdapter<TaskAdapter> VERSION = new LongFieldAdapter<>(Tasks.VERSION);
 
     /**
      * Adapter for the task row id of as instance.

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
@@ -115,6 +115,11 @@ public final class Validating implements EntityProcessor<TaskAdapter>
             throw new IllegalArgumentException("_ID can not be set manually");
         }
 
+        if (task.isUpdated(TaskAdapter.VERSION))
+        {
+            throw new IllegalArgumentException("VERSION can not be set manually");
+        }
+
         // account name can not be set on a tasks
         if (task.isUpdated(TaskAdapter.ACCOUNT_NAME))
         {

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/VersionData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/VersionData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasks;
+
+import android.content.ContentProviderOperation;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.operations.Assert;
+import org.dmfs.tasks.contract.TaskContract;
+
+
+/**
+ * {@link RowData} for the {@link TaskContract.Tasks#VERSION}.
+ * <p>
+ * Note: the task version is read-only. This {@link RowData} may only be used with {@link Assert} operations.
+ *
+ * @author Marten Gajda
+ */
+public final class VersionData implements RowData<TaskContract.Tasks>
+{
+    private final int mVersion;
+
+
+    public VersionData(int version)
+    {
+        mVersion = version;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(TaskContract.Tasks.VERSION, mVersion);
+    }
+}


### PR DESCRIPTION
This commit adds a read-only task VERSION column which is incremented upon any update or a task (including sync-adapter updates).

The column serves two purposes:

* safe transactions by asserting a specific version before updating a task
* quick detection if a specific task has been modified

The former could be used by sync-adapters to ensure a task has not been updated while being synced.
Notifications will make use of the latter to avoid unnecessary updates of task notifications for unchanged tasks.