### PR TITLE
Create version column if required, fixes #793

### DIFF
--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
@@ -22,6 +22,9 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
 
+import org.dmfs.jems.optional.adapters.First;
+import org.dmfs.jems.predicate.elementary.Equals;
+import org.dmfs.provider.tasks.utils.TableColumns;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Properties;
 import org.dmfs.tasks.contract.TaskContract.Property.Alarm;
@@ -60,7 +63,7 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
     /**
      * The database version.
      */
-    private static final int DATABASE_VERSION = 20;
+    private static final int DATABASE_VERSION = 21;
 
 
     /**
@@ -823,13 +826,16 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
             db.execSQL(SQL_CREATE_INSTANCE_CLIENT_VIEW);
         }
 
-        if (oldVersion < 20)
+        if (oldVersion < 21)
         {
-            // create task version column and update trigger
-            db.execSQL("alter table " + Tables.TASKS + " add column " + Tasks.VERSION + " Integer default 0;");
-            db.execSQL(SQL_CREATE_TASK_VERSION_TRIGGER);
+            // create version column, unless it already exists
+            if (!new First<>(new TableColumns(Tables.TASKS).value(db), new Equals<>(Tasks.VERSION)).isPresent())
+            {
+                // create task version column and update trigger
+                db.execSQL("alter table " + Tables.TASKS + " add column " + Tasks.VERSION + " Integer default 0;");
+                db.execSQL(SQL_CREATE_TASK_VERSION_TRIGGER);
+            }
         }
-
         // upgrade FTS
         FTSDatabaseHelper.onUpgrade(db, oldVersion, newVersion);
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TableColumns.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TableColumns.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.database.Cursor;
+import android.database.DatabaseUtils;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.jems.function.Function;
+
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * A {@link Function} which returns all column names of a specific table on a given database.
+ *
+ * @author Marten Gajda
+ */
+public final class TableColumns implements Function<SQLiteDatabase, Iterable<String>>
+{
+    private final String mTableName;
+
+
+    public TableColumns(String tableName)
+    {
+        mTableName = tableName;
+    }
+
+
+    @Override
+    public Iterable<String> value(SQLiteDatabase db)
+    {
+        try (Cursor cursor = db.rawQuery(String.format("PRAGMA table_info(%s)", DatabaseUtils.sqlEscapeString(mTableName)), null))
+        {
+            int nameIdx = cursor.getColumnIndexOrThrow("name");
+
+            List<String> result = new LinkedList<>();
+            while (cursor.moveToNext())
+            {
+                result.add(cursor.getString(nameIdx));
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
The cause of issue #793 is actually unknown but this once could be a good candidate. In few cases the database might already be on version 20 but the version column had not been created.
This might be caused by having the beta version installed before (which already had a version 20, but without the column).

This fix always checks if the version column already exists and creates it otherwise.