### PR TITLE
Add initial recurrence support, implements #462

### DIFF
--- a/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
+++ b/opentasks-contract/src/main/java/org/dmfs/tasks/contract/TaskContract.java
@@ -776,8 +776,8 @@ public final class TaskContract
         String ORIGINAL_INSTANCE_ID = "original_instance_id";
 
         /**
-         * The time in milliseconds since the Epoch of the original instance that is overridden by this instance or <code>null</code> if this task is not an
-         * exception.
+         * The time in milliseconds since the Epoch of the original instance that is overridden by this instance or <code>null</code> if this task is not a
+         * recurring instance.
          * <p>
          * Value: Long
          * </p>

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderRecurrenceTest.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderRecurrenceTest.java
@@ -1,0 +1,981 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks;
+
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.os.Build;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.OperationsQueue;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.operations.Assert;
+import org.dmfs.android.contentpal.operations.BulkAssert;
+import org.dmfs.android.contentpal.operations.BulkDelete;
+import org.dmfs.android.contentpal.operations.BulkUpdate;
+import org.dmfs.android.contentpal.operations.Counted;
+import org.dmfs.android.contentpal.operations.Put;
+import org.dmfs.android.contentpal.predicates.AllOf;
+import org.dmfs.android.contentpal.predicates.EqArg;
+import org.dmfs.android.contentpal.predicates.Not;
+import org.dmfs.android.contentpal.predicates.ReferringTo;
+import org.dmfs.android.contentpal.queues.BasicOperationsQueue;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.rowdata.Composite;
+import org.dmfs.android.contentpal.rowdata.EmptyRowData;
+import org.dmfs.android.contentpal.rowsnapshots.VirtualRowSnapshot;
+import org.dmfs.android.contenttestpal.operations.AssertEmptyTable;
+import org.dmfs.android.contenttestpal.operations.AssertRelated;
+import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.opentaskspal.tables.InstanceTable;
+import org.dmfs.opentaskspal.tables.LocalTaskListsTable;
+import org.dmfs.opentaskspal.tables.TaskListScoped;
+import org.dmfs.opentaskspal.tables.TaskListsTable;
+import org.dmfs.opentaskspal.tables.TasksTable;
+import org.dmfs.opentaskspal.tasks.DueData;
+import org.dmfs.opentaskspal.tasks.ExDatesTaskData;
+import org.dmfs.opentaskspal.tasks.OriginalInstanceData;
+import org.dmfs.opentaskspal.tasks.OriginalInstanceSyncIdData;
+import org.dmfs.opentaskspal.tasks.RDatesTaskData;
+import org.dmfs.opentaskspal.tasks.RRuleTaskData;
+import org.dmfs.opentaskspal.tasks.StatusData;
+import org.dmfs.opentaskspal.tasks.SyncIdData;
+import org.dmfs.opentaskspal.tasks.TimeData;
+import org.dmfs.opentaskspal.tasks.TitleData;
+import org.dmfs.opentaskstestpal.InstanceTestData;
+import org.dmfs.optional.Present;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
+import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.dmfs.tasks.contract.TaskContract.Instances;
+import org.dmfs.tasks.contract.TaskContract.TaskLists;
+import org.dmfs.tasks.contract.TaskContract.Tasks;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.TimeZone;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import static org.dmfs.android.contenttestpal.ContentMatcher.resultsIn;
+import static org.dmfs.optional.Absent.absent;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Recurrence Tests for {@link TaskProvider}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(AndroidJUnit4.class)
+public class TaskProviderRecurrenceTest
+{
+    private String mAuthority;
+    private Context mContext;
+    private ContentProviderClient mClient;
+
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mContext = InstrumentationRegistry.getTargetContext();
+        mAuthority = AuthorityUtil.taskAuthority(mContext);
+        mClient = mContext.getContentResolver().acquireContentProviderClient(mAuthority);
+
+        // Assert that tables are empty:
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new Seq<Operation<?>>(
+                new AssertEmptyTable<>(new TasksTable(mAuthority)),
+                new AssertEmptyTable<>(new TaskListsTable(mAuthority)),
+                new AssertEmptyTable<>(new InstanceTable(mAuthority))));
+        queue.flush();
+    }
+
+
+    @After
+    public void tearDown() throws Exception
+    {
+        /*
+        TODO When Test Orchestration is available, there will be no need for clean up here and check in setUp(), every test method will run in separate instrumentation
+        https://android-developers.googleblog.com/2017/07/android-testing-support-library-10-is.html
+        https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator
+        */
+
+        // Clear the DB:
+        BasicOperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new SingletonIterable<Operation<?>>(new BulkDelete<>(new LocalTaskListsTable(mAuthority))));
+        queue.flush();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            mClient.close();
+        }
+        else
+        {
+            mClient.release();
+        }
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART, DUE and an RRULE.
+     */
+    @Test
+    public void testRRule() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"))),
+//                new Counted<>(5, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp())) */)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DUE and an RRULE but no DTSTART.
+     */
+    @Test
+    public void testRRuleNoDtStart() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        DateTime due = DateTime.parse("20180104T123456Z");
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localDue.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new DueData<>(due),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new DueData<>(due),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"))),
+//                new Counted<>(5, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(absent(), new Present<>(localDue), new Present<>(due), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, due.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(absent(), new Present<>(second), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(absent(), new Present<>(third), new Present<>(third), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(absent(), new Present<>(fourth), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(absent(), new Present<>(fifth), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and an RRULE but no DUE
+     */
+    @Test
+    public void testRRuleNoDue() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        DateTime start = DateTime.parse("20180104T123456Z");
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"))),
+//                new Counted<>(5, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(new Present<>(localStart), absent(), new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(new Present<>(second), absent(), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(new Present<>(third), absent(), new Present<>(third), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(new Present<>(fourth), absent(), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(new Present<>(fifth), absent(), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Remove an instance from a task with an RRULE.
+     */
+    @Ignore("Test tries to delete 3rd instance which has not been created because currently only 1 instance is expanded")
+    @Test
+    public void testRRuleRemoveInstance() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX)))),
+                        // remove the third instance
+                        new BulkDelete<>(instancesTable,
+                                new AllOf(new ReferringTo<>(Instances.TASK_ID, task), new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"),
+                                new CharSequenceRowData<>(Tasks.EXDATE, "20180106T123456Z"))),
+                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp())),
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 4th instance (now 3rd):
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance (now 4th):
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp())))
+        );
+    }
+
+
+    /**
+     * Test RRULE with overridden instance (inserted into the tasks table)
+     */
+    @Test
+    public void testRRuleWithOverride() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        RowSnapshot<Tasks> taskOverride = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new TitleData("original"),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX)))),
+                        // the override moves the instance by an hour
+                        new Put<>(taskOverride, new Composite<>(
+                                new TimeData<>(third.addDuration(hour), third.addDuration(hour).addDuration(hour)),
+                                new TitleData("override"),
+                                new OriginalInstanceData(task, third)))
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.TITLE, "original"),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"))),
+                new Assert<>(taskOverride,
+                        new Composite<>(
+                                new TimeData<>(third.addDuration(hour), third.addDuration(hour).addDuration(hour)),
+                                new CharSequenceRowData<>(Tasks.TITLE, "override"),
+                                new OriginalInstanceData(task, third))),
+//                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, taskOverride)),
+                new Counted<>(0, new AssertRelated<>(instancesTable, Instances.TASK_ID, taskOverride)),
+//                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3th instance (the overridden one):
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, taskOverride,
+                        new InstanceTestData(third.addDuration(hour), third.addDuration(hour).addDuration(hour), new Present<>(third),
+                                2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test RRULE with overridden instance (via update on the instances table). This time we don't override the date time fields and expect the instance to
+     * inherit the original instance start and due (instead of the master start and due)
+     */
+    @Ignore("Test tries to override the 3rd instance which has not been created because we currently only expand one instance.")
+    @Test
+    public void testRRuleWithOverride2() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Tasks> tasksTable = new TasksTable(mAuthority);
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, tasksTable));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new TitleData("original"),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX)))),
+                        // the override just changes the title
+                        new BulkUpdate<>(instancesTable,
+                                new Composite<>(
+                                        new CharSequenceRowData<Instances>(Tasks.TITLE, "override")),
+                                new AllOf(new ReferringTo<>(Instances.TASK_ID, task), new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())))
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.TITLE, "original"),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"))),
+                new AssertRelated<>(tasksTable, Tasks.ORIGINAL_INSTANCE_ID, task,
+                        new Composite<>(
+                                // note the task table contains the original time zone, not the default one
+                                new TimeData<>(third.shiftTimeZone(start.getTimeZone()), third.shiftTimeZone(start.getTimeZone()).addDuration(hour)),
+                                new CharSequenceRowData<>(Tasks.TITLE, "override"),
+                                new OriginalInstanceData(task, third))),
+                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.ORIGINAL_INSTANCE_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp())),
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3th instance (the overridden one). We don't have a row reference to this row, so we select it by the ORIGINAL_INSTANCE-ID
+                new AssertRelated<>(instancesTable, Tasks.ORIGINAL_INSTANCE_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp())))
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART, an RRULE and EXDATEs.
+     */
+    @Test
+    public void testRRuleWithExDates() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RRuleTaskData(new RecurrenceRule("FREQ=DAILY;COUNT=5", RecurrenceRule.RfcMode.RFC2445_LAX)),
+                                        new ExDatesTaskData(new Seq<>(third, fifth))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RRULE, "FREQ=DAILY;COUNT=5"),
+                                new CharSequenceRowData<>(Tasks.EXDATE, "20180106T123456Z,20180108T123456Z"))),
+//                new Counted<>(3, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 4th instance (now 3rd):
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and RDATEs.
+     */
+    @Test
+    public void testRDate() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RDatesTaskData(new Seq<>(start, second, third, fourth, fifth))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RDATE,
+                                        "20180104T123456Z," +
+                                                "20180105T123456Z," +
+                                                "20180106T123456Z," +
+                                                "20180107T123456Z," +
+                                                "20180108T123456Z"
+                                ))),
+//                new Counted<>(5, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 4),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and RDATEs, add exdate afterwards.
+     */
+    @Test
+    public void testRDateAddExDate() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RDatesTaskData(new Seq<>(start, second, third, fourth, fifth)))),
+                        // the third instance becomed an exdate now
+                        new Put<>(task,
+                                new Composite<>(
+                                        new ExDatesTaskData(new Seq<>(third))))
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RDATE,
+                                        "20180104T123456Z," +
+                                                "20180105T123456Z," +
+                                                "20180106T123456Z," +
+                                                "20180107T123456Z," +
+                                                "20180108T123456Z"),
+                                new CharSequenceRowData<>(Tasks.EXDATE,
+                                        "20180106T123456Z"
+                                ))),
+//                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()))/*,
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp())),
+                // 3rd instance:
+//                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+//                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 2),
+//                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and RDATEs, complete first.
+     */
+    @Test
+    public void testRDateFirstComplete() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        RowSnapshot<Tasks> override = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        // first insert new task,
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RDatesTaskData(new Seq<>(start, second, third, fourth, fifth)))),
+                        // next, insert override
+                        new Put<>(override,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new OriginalInstanceData(task, start),
+                                        new StatusData<>(Tasks.STATUS_COMPLETED)))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RDATE,
+                                        "20180104T123456Z," +
+                                                "20180105T123456Z," +
+                                                "20180106T123456Z," +
+                                                "20180107T123456Z," +
+                                                "20180108T123456Z"
+                                ))),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, override)),
+//                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, override,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), -1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp())),
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp()))/*,
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and RDATEs, complete first inserted first.
+     */
+    @Test
+    public void testRDateFirstCompleteFirstInserted() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        RowSnapshot<Tasks> override = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        // first insert override
+                        new Put<>(override,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new OriginalInstanceSyncIdData("xyz", start),
+                                        new StatusData<>(Tasks.STATUS_COMPLETED))),
+                        // then insert task
+                        new Put<>(task,
+                                new Composite<>(
+                                        new SyncIdData("xyz"),
+                                        new TimeData<>(start, due),
+                                        new RDatesTaskData(new Seq<>(start, second, third, fourth, fifth))))
+
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new SyncIdData("xyz"),
+                                new CharSequenceRowData<>(Tasks.RDATE,
+                                        "20180104T123456Z," +
+                                                "20180105T123456Z," +
+                                                "20180106T123456Z," +
+                                                "20180107T123456Z," +
+                                                "20180108T123456Z"
+                                ))),
+                new Assert<>(override,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new OriginalInstanceSyncIdData("xyz", start),
+                                new StatusData<>(Tasks.STATUS_COMPLETED))),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, override)),
+//                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance, overridden and completed
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, override,
+                        new InstanceTestData(localStart, localDue, new Present<>(start), -1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp())),
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp()))/*,
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+
+    /**
+     * Test if instances of a task with a DTSTART and RDATEs, complete first via instances table.
+     */
+    @Test
+    public void testRDateFirstCompleteViaInstances() throws InvalidRecurrenceRuleException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        Table<Tasks> tasksTable = new TasksTable(mAuthority);
+        Table<Instances> instancesTable = new InstanceTable(mAuthority);
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, tasksTable));
+
+        Duration hour = new Duration(1, 0, 3600 /* 1 hour */);
+        DateTime start = DateTime.parse("20180104T123456Z");
+        DateTime due = start.addDuration(hour);
+
+        Duration day = new Duration(1, 1, 0);
+
+        DateTime localStart = start.shiftTimeZone(TimeZone.getDefault());
+        DateTime localDue = due.shiftTimeZone(TimeZone.getDefault());
+
+        DateTime second = localStart.addDuration(day);
+        DateTime third = second.addDuration(day);
+        DateTime fourth = third.addDuration(day);
+        DateTime fifth = fourth.addDuration(day);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new EmptyRowData<>()),
+                        // first insert the task
+                        new Put<>(task,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new RDatesTaskData(new Seq<>(start, second, third, fourth, fifth)))),
+                        // then complete the first instance
+                        new BulkUpdate<>(instancesTable, new CharSequenceRowData<>(Tasks.STATUS, String.valueOf(Tasks.STATUS_COMPLETED)),
+                                new AllOf(
+                                        new ReferringTo<>(Instances.TASK_ID, task),
+                                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp())))
+                ), resultsIn(mClient,
+                new Assert<>(task,
+                        new Composite<>(
+                                new TimeData<>(start, due),
+                                new CharSequenceRowData<>(Tasks.RDATE,
+                                        "20180104T123456Z," +
+                                                "20180105T123456Z," +
+                                                "20180106T123456Z," +
+                                                "20180107T123456Z," +
+                                                "20180108T123456Z"
+                                ))),
+                // there must be one task which is not equal to the original task
+                new Counted<>(1,
+                        new BulkAssert<>(tasksTable,
+                                new Composite<>(
+                                        new TimeData<>(start, due),
+                                        new StatusData<>(Tasks.STATUS_COMPLETED)),
+                                new Not(new ReferringTo<>(Tasks._ID, task)))),
+                // and one instance which doesn't refer to the original task
+                new Counted<>(1, new BulkAssert<>(instancesTable, new Not(new ReferringTo<>(Instances.TASK_ID, task)))),
+                // but 4 instances of that original task
+//                new Counted<>(4, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                new Counted<>(1, new AssertRelated<>(instancesTable, Instances.TASK_ID, task)),
+                // 1st instance, overridden and completed
+                new Counted<>(1, new BulkAssert<>(instancesTable,
+                        new Composite<>(
+                                new InstanceTestData(localStart, localDue, new Present<>(start), -1)),
+                        new AllOf(
+                                new EqArg(Instances.INSTANCE_ORIGINAL_TIME, start.getTimestamp()),
+                                new Not(new ReferringTo<>(Instances.TASK_ID, task))))),
+                // 2nd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(second, second.addDuration(hour), new Present<>(second), 0),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, second.getTimestamp()))/*,
+                // 3rd instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(third, third.addDuration(hour), new Present<>(third), 1),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, third.getTimestamp())),
+                // 4th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fourth, fourth.addDuration(hour), new Present<>(fourth), 2),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fourth.getTimestamp())),
+                // 5th instance:
+                new AssertRelated<>(instancesTable, Instances.TASK_ID, task,
+                        new InstanceTestData(fifth, fifth.addDuration(hour), new Present<>(fifth), 3),
+                        new EqArg(Instances.INSTANCE_ORIGINAL_TIME, fifth.getTimestamp()))*/)
+        );
+    }
+
+}

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderTest.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderTest.java
@@ -33,7 +33,6 @@ import org.dmfs.android.contentpal.operations.BulkDelete;
 import org.dmfs.android.contentpal.operations.BulkUpdate;
 import org.dmfs.android.contentpal.operations.Delete;
 import org.dmfs.android.contentpal.operations.Put;
-import org.dmfs.android.contentpal.operations.Referring;
 import org.dmfs.android.contentpal.predicates.ReferringTo;
 import org.dmfs.android.contentpal.queues.BasicOperationsQueue;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
@@ -50,6 +49,7 @@ import org.dmfs.opentaskspal.tables.TaskListScoped;
 import org.dmfs.opentaskspal.tables.TaskListsTable;
 import org.dmfs.opentaskspal.tables.TasksTable;
 import org.dmfs.opentaskspal.tasklists.NameData;
+import org.dmfs.opentaskspal.tasks.OriginalInstanceData;
 import org.dmfs.opentaskspal.tasks.OriginalInstanceSyncIdData;
 import org.dmfs.opentaskspal.tasks.StatusData;
 import org.dmfs.opentaskspal.tasks.SyncIdData;
@@ -308,11 +308,11 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
-                new Put<>(task, new TimeData(start, due))
+                new Put<>(task, new TimeData<>(start, due))
 
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, due),
+                        new TimeData<>(start, due),
                         new VersionData(0))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -341,12 +341,12 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<>()),
-                new Put<>(task, new TimeData(start, due)),
+                new Put<>(task, new TimeData<>(start, due)),
                 // update the status of the new task
-                new Put<>(task, new StatusData(Tasks.STATUS_COMPLETED))
+                new Put<>(task, new StatusData<>(Tasks.STATUS_COMPLETED))
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, due),
+                        new TimeData<>(start, due),
                         new VersionData(1))), // task has been updated once
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -375,14 +375,14 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<>()),
-                new Put<>(task, new TimeData(start, due)),
+                new Put<>(task, new TimeData<>(start, due)),
                 // update the status of the new task
-                new Put<>(task, new StatusData(Tasks.STATUS_COMPLETED)),
+                new Put<>(task, new StatusData<>(Tasks.STATUS_COMPLETED)),
                 // update the title of the new task
                 new Put<>(task, new TitleData("Task Title"))
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, due),
+                        new TimeData<>(start, due),
                         new TitleData("Task Title"),
                         new VersionData(2))), // task has been updated twice
                 new AssertRelated<>(
@@ -416,11 +416,11 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
-                new Put<>(task, new TimeData(start, due)),
-                new Put<>(task, new TimeData(startNew, dueNew))
+                new Put<>(task, new TimeData<>(start, due)),
+                new Put<>(task, new TimeData<>(startNew, dueNew))
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(startNew, dueNew),
+                        new TimeData<>(startNew, dueNew),
                         new VersionData(1))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -453,11 +453,11 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
-                new Put<>(task, new TimeData(start, due)),
-                new Put<>(task, new TimeData(startNew, dueNew))
+                new Put<>(task, new TimeData<>(start, due)),
+                new Put<>(task, new TimeData<>(startNew, dueNew))
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(startNew, dueNew),
+                        new TimeData<>(startNew, dueNew),
                         new VersionData(1))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -487,10 +487,10 @@ public class TaskProviderTest
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
                 new Put<>(task, new TitleData("Test")),
-                new Put<>(task, new TimeData(start, due))
+                new Put<>(task, new TimeData<>(start, due))
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, due),
+                        new TimeData<>(start, due),
                         new VersionData(1))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -520,11 +520,11 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
-                new Put<>(task, new TimeData(start, duration))
+                new Put<>(task, new TimeData<>(start, duration))
 
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, duration),
+                        new TimeData<>(start, duration),
                         new VersionData(0))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -555,13 +555,13 @@ public class TaskProviderTest
 
         assertThat(new Seq<>(
                 new Put<>(taskList, new EmptyRowData<TaskLists>()),
-                new Put<>(task, new TimeData(start, duration)),
+                new Put<>(task, new TimeData<>(start, duration)),
                 // update the task with a the same start in a different time zone
-                new Put<>(task, new TimeData(startNew, duration))
+                new Put<>(task, new TimeData<>(startNew, duration))
 
         ), resultsIn(mClient,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(startNew, duration),
+                        new TimeData<>(startNew, duration),
                         new VersionData(1))),
                 // note that, apart from the time zone, all values stay the same
                 new AssertRelated<>(
@@ -593,18 +593,18 @@ public class TaskProviderTest
 
         queue.enqueue(new Seq<>(
                 new Put<>(taskList, new NameData("list1")),
-                new Put<>(task, new TimeData(start, due))
+                new Put<>(task, new TimeData<>(start, due))
         ));
         queue.flush();
 
         DateTime due2 = due.addDuration(new Duration(1, 0, 2));
 
         assertThat(new SingletonIterable<>(
-                new Put<>(task, new TimeData(start, due2))
+                new Put<>(task, new TimeData<>(start, due2))
 
         ), resultsIn(queue,
                 new Assert<>(task, new Composite<>(
-                        new TimeData(start, due2),
+                        new TimeData<>(start, due2),
                         new VersionData(1))),
                 new AssertRelated<>(
                         new InstanceTable(mAuthority), Instances.TASK_ID, task,
@@ -732,7 +732,7 @@ public class TaskProviderTest
         assertThat(new SingletonIterable<>(
                 new Put<>(exceptionTask, new Composite<>(
                         new TitleData("task1exception"),
-                        new OriginalInstanceSyncIdData("syncId1"))
+                        new OriginalInstanceSyncIdData("syncId1", new DateTime(0)))
                 )
 
         ), resultsIn(queue,
@@ -759,20 +759,23 @@ public class TaskProviderTest
                 new Put<>(taskList, new NameData("list1")),
                 new Put<>(task, new Composite<>(
                         new TitleData("task1"),
-                        new SyncIdData("syncId1"))
-                )
+                        new SyncIdData("syncId1")))
         ));
         queue.flush();
 
+        DateTime now = DateTime.now();
+
         assertThat(new SingletonIterable<>(
-                new Referring<>(task, Tasks.ORIGINAL_INSTANCE_ID,
-                        new Put<>(exceptionTask, new TitleData("task1exception")))
+                new Put<>(exceptionTask,
+                        new Composite<>(
+                                new TitleData("task1exception"),
+                                new OriginalInstanceData(task, now)))
 
         ), resultsIn(queue,
                 new AssertRelated<>(new TasksTable(mAuthority), Tasks.ORIGINAL_INSTANCE_ID, task,
                         new Composite<>(
                                 new TitleData("task1exception"),
-                                new OriginalInstanceSyncIdData("syncId1")
+                                new OriginalInstanceSyncIdData("syncId1", now)
                         ))
         ));
     }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskDatabaseHelper.java
@@ -18,12 +18,18 @@ package org.dmfs.provider.tasks;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
 
 import org.dmfs.jems.optional.adapters.First;
 import org.dmfs.jems.predicate.elementary.Equals;
+import org.dmfs.provider.tasks.model.CursorContentValuesTaskAdapter;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.provider.tasks.processors.EntityProcessor;
+import org.dmfs.provider.tasks.processors.NoOpProcessor;
+import org.dmfs.provider.tasks.processors.tasks.Instantiating;
 import org.dmfs.provider.tasks.utils.TableColumns;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Properties;
@@ -31,6 +37,8 @@ import org.dmfs.tasks.contract.TaskContract.Property.Alarm;
 import org.dmfs.tasks.contract.TaskContract.Property.Category;
 import org.dmfs.tasks.contract.TaskContract.TaskLists;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
+
+import java.util.Locale;
 
 
 /**
@@ -63,7 +71,7 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
     /**
      * The database version.
      */
-    private static final int DATABASE_VERSION = 21;
+    private static final int DATABASE_VERSION = 22;
 
 
     /**
@@ -826,7 +834,7 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
             db.execSQL(SQL_CREATE_INSTANCE_CLIENT_VIEW);
         }
 
-        if (oldVersion < 21)
+        if (oldVersion < 22)
         {
             // create version column, unless it already exists
             if (!new First<>(new TableColumns(Tables.TASKS).value(db), new Equals<>(Tasks.VERSION)).isPresent())
@@ -836,6 +844,37 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
                 db.execSQL(SQL_CREATE_TASK_VERSION_TRIGGER);
             }
         }
+
+        if (oldVersion < 22)
+        {
+            db.beginTransaction();
+            try
+            {
+                // make sure we upgrade the instances of every recurring task
+                EntityProcessor<TaskAdapter> processor = new Instantiating(new NoOpProcessor<>());
+                try (Cursor c = db.query(Tables.TASKS,
+                        new String[] {
+                                TaskContract.Tasks._ID, Tasks.ORIGINAL_INSTANCE_ID, Tasks.DTSTART, Tasks.DUE, Tasks.DURATION, Tasks.IS_CLOSED, Tasks.TZ,
+                                Tasks.IS_ALLDAY, Tasks.RRULE, Tasks.RDATE, Tasks.EXDATE, Tasks.ORIGINAL_INSTANCE_TIME, Tasks.ORIGINAL_INSTANCE_ALLDAY },
+                        String.format(Locale.ENGLISH, "%s is null", TaskContract.Tasks.ORIGINAL_INSTANCE_ID),
+                        null, null, null, null))
+                {
+                    while (c.moveToNext())
+                    {
+                        ContentValues values = new ContentValues();
+                        Instantiating.addUpdateRequest(values);
+                        TaskAdapter adapter = new CursorContentValuesTaskAdapter(c, values);
+                        processor.update(db, adapter, false);
+                    }
+                }
+                db.setTransactionSuccessful();
+            }
+            finally
+            {
+                db.endTransaction();
+            }
+        }
+
         // upgrade FTS
         FTSDatabaseHelper.onUpgrade(db, oldVersion, newVersion);
 
@@ -844,4 +883,5 @@ public class TaskDatabaseHelper extends SQLiteOpenHelper
             mListener.onDatabaseUpdate(db, oldVersion, newVersion);
         }
     }
+
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/handler/PropertyHandler.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/handler/PropertyHandler.java
@@ -139,6 +139,17 @@ public abstract class PropertyHandler
     protected void updateFTSEntry(SQLiteDatabase db, long taskId, long propertyId, String text)
     {
         FTSDatabaseHelper.updatePropertyFTSEntry(db, taskId, propertyId, text);
-
     }
+
+
+    public ContentValues cloneForNewTask(long newTaskId, ContentValues values)
+    {
+        ContentValues newValues = new ContentValues(values);
+        newValues.remove(Properties.PROPERTY_ID);
+        newValues.put(Properties.TASK_ID, newTaskId);
+        return newValues;
+    }
+
+
+    ;
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/handler/RelationHandler.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/handler/RelationHandler.java
@@ -72,6 +72,15 @@ public class RelationHandler extends PropertyHandler
 
 
     @Override
+    public ContentValues cloneForNewTask(long newTaskId, ContentValues values)
+    {
+        ContentValues newValues = super.cloneForNewTask(newTaskId, values);
+        newValues.remove(Relation.RELATED_CONTENT_URI);
+        return newValues;
+    }
+
+
+    @Override
     public int update(SQLiteDatabase db, long taskId, long propertyId, ContentValues values, Cursor oldValues, boolean isSyncAdapter)
     {
         validateValues(db, taskId, propertyId, false, values, isSyncAdapter);
@@ -250,11 +259,11 @@ public class RelationHandler extends PropertyHandler
         }
         // else if (type == Relation.RELTYPE_SIBLING)
         // {
-            /*
-             * This was a link to a sibling, since it's no longer our sibling either it or we're orphaned now We won't know unless we check all relations.
-             *
-             * FIXME: properly handle this case
-             */
+        /*
+         * This was a link to a sibling, since it's no longer our sibling either it or we're orphaned now We won't know unless we check all relations.
+         *
+         * FIXME: properly handle this case
+         */
         // }
     }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/InstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/InstanceAdapter.java
@@ -22,6 +22,7 @@ import android.database.Cursor;
 import org.dmfs.provider.tasks.model.adapters.DateTimeFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.IntegerFieldAdapter;
 import org.dmfs.provider.tasks.model.adapters.LongFieldAdapter;
+import org.dmfs.provider.tasks.model.adapters.StringFieldAdapter;
 import org.dmfs.tasks.contract.TaskContract.Instances;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
@@ -67,6 +68,11 @@ public interface InstanceAdapter extends EntityAdapter<InstanceAdapter>
      * Adapter for the distance of a task instance from the current instance.
      */
     IntegerFieldAdapter<InstanceAdapter> DISTANCE_FROM_CURRENT = new IntegerFieldAdapter<>(Instances.DISTANCE_FROM_CURRENT);
+
+    /**
+     * Adapter for the title of a task instance.
+     */
+    StringFieldAdapter<InstanceAdapter> TITLE = new StringFieldAdapter<>(Tasks.TITLE);
 
     /**
      * Adapter for the row id of the task.

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/NoOpProcessor.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/NoOpProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.processors;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.model.EntityAdapter;
+
+
+/**
+ * A simple No-Op {@link EntityProcessor}.
+ *
+ * @author Marten Gajda
+ */
+public final class NoOpProcessor<T extends EntityAdapter<T>> implements EntityProcessor<T>
+{
+    @Override
+    public T insert(SQLiteDatabase db, T entityAdapter, boolean isSyncAdapter)
+    {
+        return entityAdapter;
+    }
+
+
+    @Override
+    public T update(SQLiteDatabase db, T entityAdapter, boolean isSyncAdapter)
+    {
+        return entityAdapter;
+    }
+
+
+    @Override
+    public void delete(SQLiteDatabase db, T entityAdapter, boolean isSyncAdapter)
+    {
+        // do nothing
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/TaskValueDelegate.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/instances/TaskValueDelegate.java
@@ -18,6 +18,7 @@ package org.dmfs.provider.tasks.processors.instances;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 
 import org.dmfs.iterables.decorators.Filtered;
@@ -28,6 +29,8 @@ import org.dmfs.jems.optional.adapters.FirstPresent;
 import org.dmfs.jems.optional.elementary.NullSafe;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.handler.PropertyHandler;
+import org.dmfs.provider.tasks.handler.PropertyHandlerFactory;
 import org.dmfs.provider.tasks.model.ContentValuesInstanceAdapter;
 import org.dmfs.provider.tasks.model.CursorContentValuesTaskAdapter;
 import org.dmfs.provider.tasks.model.InstanceAdapter;
@@ -59,6 +62,7 @@ public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
             TaskAdapter.SYNC_ID,
             TaskAdapter.SYNC_VERSION,
             // unset any list and read-only fields
+            TaskAdapter.VERSION,
             TaskAdapter.ACCOUNT_NAME,
             TaskAdapter.ACCOUNT_TYPE,
             TaskAdapter.LIST_VISIBLE,
@@ -92,10 +96,11 @@ public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
     public InstanceAdapter insert(SQLiteDatabase db, InstanceAdapter entityAdapter, boolean isSyncAdapter)
     {
         TaskAdapter taskAdapter = entityAdapter.taskAdapter();
+        Long masterTaskId = null;
         if (taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID) != null)
         {
             // this is going to be an override to an existing task - make sure we add an RDATE first
-            long masterTaskId = taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID);
+            masterTaskId = taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID);
             DateTime originalTime = taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_TIME);
             // get the master and add an rdate
             try (Cursor c = db.query(TaskDatabaseHelper.Tables.TASKS, null /* all */, TaskContract.Tasks._ID + "=" + masterTaskId, null, null, null, null))
@@ -129,6 +134,12 @@ public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
 
         // move on with inserting the instance
         TaskAdapter taskResult = mDelegate.insert(db, entityAdapter.taskAdapter(), false);
+
+        if (masterTaskId != null)
+        {
+            // we just cloned the master task into a new instance, we need to copy the properties as well
+            copyProperties(db, masterTaskId, taskResult.id());
+        }
 
         try (Cursor c = db.query(TaskDatabaseHelper.Tables.INSTANCES, new String[] { TaskContract.Instances._ID },
                 TaskContract.Instances.TASK_ID + "=" + taskResult.id(), null, null, null, null))
@@ -174,7 +185,9 @@ public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
             override.set(TaskAdapter.ORIGINAL_INSTANCE_ALLDAY, taskAdapter.valueOf(TaskAdapter.IS_ALLDAY));
 
             // TODO: if this is the first instance (and maybe no other overrides exist), don't create an override but split the series into two tasks
-            mDelegate.insert(db, override, true /* for now insert as a sync adapter to retain the UID */);
+            TaskAdapter newTask = mDelegate.insert(db, override, true /* for now insert as a sync adapter to retain the UID */);
+
+            copyProperties(db, taskAdapter.id(), newTask.id());
         }
         else
         {
@@ -237,5 +250,34 @@ public final class TaskValueDelegate implements EntityProcessor<InstanceAdapter>
     {
         taskAdapter.set(addfieldAdapter, new Joined<>(new Filtered<>(taskAdapter.valueOf(addfieldAdapter), new NoneOf<>(dateTime)), new Seq<>(dateTime)));
         taskAdapter.set(removefieldAdapter, new Filtered<>(taskAdapter.valueOf(removefieldAdapter), new NoneOf<>(dateTime)));
+    }
+
+
+    /**
+     * Copy the properties from the give original task to the new task.
+     *
+     * @param db
+     *         The {@link SQLiteDatabase}
+     * @param originalId
+     *         The ID of the task of which to copy the properties
+     * @param newId
+     *         The ID of the task to copy the properties to.
+     */
+    private void copyProperties(SQLiteDatabase db, long originalId, long newId)
+    {
+        // for each property of the original task
+        try (Cursor c = db.query(TaskDatabaseHelper.Tables.PROPERTIES, null /* all */,
+                String.format(Locale.ENGLISH, "%s = %d", TaskContract.Properties.TASK_ID, originalId), null, null, null, null))
+        {
+            // load the property and insert it for the new task
+            ContentValues values = new ContentValues(c.getColumnCount());
+            while (c.moveToNext())
+            {
+                values.clear();
+                DatabaseUtils.cursorRowToContentValues(c, values);
+                PropertyHandler ph = PropertyHandlerFactory.get(values.getAsString(TaskContract.Properties.MIMETYPE));
+                ph.insert(db, newId, ph.cloneForNewTask(newId, values), false);
+            }
+        }
     }
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Instantiating.java
@@ -25,9 +25,11 @@ import org.dmfs.jems.iterable.decorators.Mapped;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.elementary.NullSafe;
 import org.dmfs.jems.pair.Pair;
+import org.dmfs.jems.pair.elementary.RightSidedPair;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.CursorContentValuesTaskAdapter;
 import org.dmfs.provider.tasks.model.TaskAdapter;
 import org.dmfs.provider.tasks.model.adapters.BooleanFieldAdapter;
 import org.dmfs.provider.tasks.processors.EntityProcessor;
@@ -42,8 +44,6 @@ import java.util.Locale;
 
 /**
  * A processor that creates or updates the instance values of a task.
- * <p>
- * TODO: At present this does not support recurrence.
  *
  * @author Marten Gajda
  */
@@ -59,7 +59,8 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
     private final static BooleanFieldAdapter<TaskAdapter> UPDATE_REQUESTED = new BooleanFieldAdapter<TaskAdapter>(
             "org.dmfs.tasks.TaskInstanceProcessor.UPDATE_REQUESTED");
 
-    private final static int INSTANCE_COUNT_LIMIT = 1000;
+    // for now we only expand the next upcoming instance
+    private final static int UPCOMING_INSTANCE_COUNT_LIMIT = 1;
 
 
     /**
@@ -87,7 +88,16 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
     public TaskAdapter insert(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
     {
         TaskAdapter result = mDelegate.insert(db, task, isSyncAdapter);
-        createInstances(db, result, task.id());
+        if (task.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID) != null)
+        {
+            // an override was created, insert a single task
+            updateOverrideInstance(db, result, result.id());
+        }
+        else
+        {
+            // update the recurring instances, there may already be overrides, so we use the update method
+            updateMasterInstances(db, result, result.id());
+        }
         return result;
     }
 
@@ -102,12 +112,20 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
         TaskAdapter result = mDelegate.update(db, task, isSyncAdapter);
 
         if (!result.isUpdated(TaskAdapter.DTSTART) && !result.isUpdated(TaskAdapter.DUE) && !result.isUpdated(TaskAdapter.DURATION)
-                && !result.isUpdated(TaskAdapter.STATUS) && !updateRequested)
+                && !result.isUpdated(TaskAdapter.STATUS) && !result.isUpdated(TaskAdapter.RDATE) && !result.isUpdated(TaskAdapter.RRULE) && !result.isUpdated(
+                TaskAdapter.EXDATE) && !result.isUpdated(TaskAdapter.IS_CLOSED) && !updateRequested)
         {
             // date values didn't change and update not requested -> no need to update the instances table
             return result;
         }
-        updateInstances(db, result, task.id());
+        if (task.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID) == null)
+        {
+            updateMasterInstances(db, result, result.id());
+        }
+        else
+        {
+            updateOverrideInstance(db, result, result.id());
+        }
         return result;
     }
 
@@ -121,7 +139,7 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
 
 
     /**
-     * Creates instances for a new task.
+     * Update the instance of an override.
      * <p>
      * TODO: take instance overrides into account
      *
@@ -132,12 +150,51 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
      * @param id
      *         the row id of the new task.
      */
-    private void createInstances(SQLiteDatabase db, TaskAdapter taskAdapter, long id)
+    private void updateOverrideInstance(SQLiteDatabase db, TaskAdapter taskAdapter, long id)
     {
-        // TODO: only limit future instances
-        for (Single<ContentValues> values : new Limited<>(INSTANCE_COUNT_LIMIT, new InstanceValuesIterable(taskAdapter)))
+        long origId = taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_ID);
+        int count = 0;
+        for (Single<ContentValues> values : new InstanceValuesIterable(taskAdapter))
         {
-            db.insert(TaskDatabaseHelper.Tables.INSTANCES, "", new TaskRelated(id, values).value());
+            if (count++ > 1)
+            {
+                throw new RuntimeException("more than one instance returned for task which was supposed to have exactly one");
+            }
+            try (Cursor c = db.query(TaskDatabaseHelper.Tables.INSTANCE_VIEW, new String[] { TaskContract.Instances._ID },
+                    String.format(Locale.ENGLISH, "(%s = %d or %s = %d) and (%s = %d) ",
+                            TaskContract.Instances.TASK_ID,
+                            origId,
+                            TaskContract.Instances.ORIGINAL_INSTANCE_ID,
+                            origId,
+                            TaskContract.Instances.INSTANCE_ORIGINAL_TIME,
+                            taskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_TIME).getTimestamp()),
+                    null, null, null, null))
+            {
+                if (c.moveToFirst())
+                {
+                    db.update(TaskDatabaseHelper.Tables.INSTANCES, new TaskRelated(id, values).value(), String.format(Locale.ENGLISH, "%s = %d",
+                            TaskContract.Instances._ID, c.getLong(0)), null);
+                }
+                else
+                {
+                    db.insert(TaskDatabaseHelper.Tables.INSTANCES, "", new TaskRelated(id, values).value());
+                }
+            }
+        }
+        if (count == 0)
+        {
+            throw new RuntimeException("no instance returned for task which was supposed to have exactly one");
+        }
+
+        // ensure the distance from current is set properly for all sibling instances
+        try (Cursor c = db.query(TaskDatabaseHelper.Tables.TASKS, null,
+                String.format(Locale.ENGLISH, "(%s = %d)", TaskContract.Tasks._ID, origId), null, null, null, null))
+        {
+            if (c.moveToFirst())
+            {
+                TaskAdapter ta = new CursorContentValuesTaskAdapter(c, new ContentValues());
+                updateMasterInstances(db, ta, ta.id());
+            }
         }
     }
 
@@ -154,35 +211,38 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
      * @param id
      *         the row id of the new task
      */
-    private void updateInstances(SQLiteDatabase db, TaskAdapter taskAdapter, long id)
+    private void updateMasterInstances(SQLiteDatabase db, TaskAdapter taskAdapter, long id)
     {
-        // get a cursor of all existing instances
         final Cursor existingInstances = db.query(
                 TaskDatabaseHelper.Tables.INSTANCE_VIEW,
-                new String[] { TaskContract.Instances._ID, TaskContract.Instances.INSTANCE_ORIGINAL_TIME },
-                String.format(Locale.ENGLISH, "%s = %d", TaskContract.Instances.TASK_ID, id),
+                new String[] {
+                        TaskContract.Instances._ID, TaskContract.Instances.INSTANCE_ORIGINAL_TIME, TaskContract.Instances.TASK_ID,
+                        TaskContract.Instances.IS_CLOSED, TaskContract.Instances.DISTANCE_FROM_CURRENT },
+                String.format(Locale.ENGLISH, "%s = %d or %s = %d", TaskContract.Instances.TASK_ID, id, TaskContract.Instances.ORIGINAL_INSTANCE_ID, id),
                 null,
                 null,
                 null,
                 TaskContract.Instances.INSTANCE_ORIGINAL_TIME);
 
-
         /*
          * The goal of the code below is to update existing instances in place (as opposed to delete and recreate all instances). We do this for two reasons:
-         * 1) efficiency, in most cases existing instances don't change, deleting and recreating them would be very expensive
+         * 1) efficiency, in most cases existing instances don't change, deleting and recreating them would be overly expensive
          * 2) stable row ids, deleting and recreating instances would change their id and void any existing URIs to them
          */
         try
         {
-            int idIdx = existingInstances.getColumnIndex(TaskContract.Instances._ID);
+            final int idIdx = existingInstances.getColumnIndex(TaskContract.Instances._ID);
             final int startIdx = existingInstances.getColumnIndex(TaskContract.Instances.INSTANCE_ORIGINAL_TIME);
+            final int taskIdIdx = existingInstances.getColumnIndex(TaskContract.Instances.TASK_ID);
+            final int isClosedIdx = existingInstances.getColumnIndex(TaskContract.Instances.IS_CLOSED);
+            final int distanceIdx = existingInstances.getColumnIndex(TaskContract.Instances.DISTANCE_FROM_CURRENT);
 
             // get an Iterator of all expected instances
             // for very long or even infinite series we need to stop iterating at some point.
-            // TODO: once we actually support recurrence we should only count future instances
 
             Iterable<Pair<Optional<ContentValues>, Optional<Integer>>> diff = new Diff<>(
-                    new Mapped<>(Single::value, new Limited<>(INSTANCE_COUNT_LIMIT, new InstanceValuesIterable(taskAdapter))),
+                    new Mapped<>(Single::value,
+                            new Limited<>(10000 /* hard limit for infinite rules*/, new InstanceValuesIterable(taskAdapter))),
                     new Range(existingInstances.getCount()),
                     (newInstanceValues, cursorRow) ->
                     {
@@ -191,9 +251,21 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
                                 - existingInstances.getLong(startIdx));
                     });
 
+            int distance = -1;
             // sync the instances table with the new instances
             for (Pair<Optional<ContentValues>, Optional<Integer>> next : diff)
             {
+                if (distance >= UPCOMING_INSTANCE_COUNT_LIMIT - 1)
+                {
+                    // if we already expanded enough instances, we pretend no other instance exists
+                    if (!next.right().isPresent())
+                    {
+                        // actually no instance exists, no need to do anything
+                        continue;
+                    }
+                    next = new RightSidedPair<>(next.right());
+                }
+
                 if (!next.left().isPresent())
                 {
                     // there is no new instance for this old one, remove it
@@ -206,15 +278,46 @@ public final class Instantiating implements EntityProcessor<TaskAdapter>
                     // there is no old instance for this new one, add it
                     ContentValues values = next.left().value();
                     values.put(TaskContract.Instances.TASK_ID, taskAdapter.id());
+                    if (distance >= 0 || !taskAdapter.valueOf(TaskAdapter.IS_CLOSED))
+                    {
+                        distance += 1;
+                    }
+                    values.put(TaskContract.Instances.DISTANCE_FROM_CURRENT, distance);
                     db.insert(TaskDatabaseHelper.Tables.INSTANCES, "", values);
                 }
                 else // both sides are present
                 {
                     // update this instance
                     existingInstances.moveToPosition(next.right().value());
-                    // TODO: only update if something has changed
-                    db.update(TaskDatabaseHelper.Tables.INSTANCES, next.left().value(),
-                            String.format(Locale.ENGLISH, "%s = %d", TaskContract.Instances._ID, existingInstances.getLong(idIdx)), null);
+                    // only update if the instance belongs to this task
+                    if (existingInstances.getLong(taskIdIdx) == id)
+                    {
+                        ContentValues values = next.left().value();
+                        if (distance >= 0 ||
+                                taskAdapter.isUpdated(TaskAdapter.IS_CLOSED) && !taskAdapter.valueOf(TaskAdapter.IS_CLOSED) ||
+                                !taskAdapter.isUpdated(TaskAdapter.IS_CLOSED) && existingInstances.getInt(isClosedIdx) == 0)
+                        {
+                            // the distance needs to be updated
+                            distance += 1;
+                            values.put(TaskContract.Instances.DISTANCE_FROM_CURRENT, distance);
+                        }
+
+                        // TODO: only update if something actually changed
+                        db.update(TaskDatabaseHelper.Tables.INSTANCES, values,
+                                String.format(Locale.ENGLISH, "%s = %d", TaskContract.Instances._ID, existingInstances.getLong(idIdx)), null);
+                    }
+                    else if (distance >= 0 || existingInstances.getInt(isClosedIdx) == 0)
+                    {
+                        // this is an override and we need to check the distance value
+                        distance += 1;
+                        if (distance != existingInstances.getInt(distanceIdx))
+                        {
+                            ContentValues contentValues = new ContentValues(1);
+                            contentValues.put(TaskContract.Instances.DISTANCE_FROM_CURRENT, distance);
+                            db.update(TaskDatabaseHelper.Tables.INSTANCES, contentValues,
+                                    String.format(Locale.ENGLISH, "%s = %d", TaskContract.Instances._ID, existingInstances.getLong(idIdx)), null);
+                        }
+                    }
                 }
             }
         }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Originating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Originating.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.processors.tasks;
+
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.dmfs.provider.tasks.TaskDatabaseHelper;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.provider.tasks.processors.EntityProcessor;
+import org.dmfs.tasks.contract.TaskContract;
+
+import java.util.Locale;
+
+
+/**
+ * An {@link EntityProcessor} which updates the {@link TaskContract.Tasks#ORIGINAL_INSTANCE_ID} of any overrides when a master is inserted which has the
+ * matching {@link TaskContract.Tasks#ORIGINAL_INSTANCE_SYNC_ID}.
+ *
+ * @author Marten Gajda
+ */
+public final class Originating implements EntityProcessor<TaskAdapter>
+{
+    private final EntityProcessor<TaskAdapter> mDelegate;
+
+
+    public Originating(EntityProcessor<TaskAdapter> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public TaskAdapter insert(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
+    {
+        TaskAdapter result = mDelegate.insert(db, task, isSyncAdapter);
+        String syncId = result.valueOf(TaskAdapter.SYNC_ID);
+        if (syncId != null)
+        {
+            // A master task with a syncId has been inserted.
+            // Update original ID of any existing overrides.
+            ContentValues values = new ContentValues(1);
+            values.put(TaskContract.Tasks.ORIGINAL_INSTANCE_ID, result.id());
+            db.update(TaskDatabaseHelper.Tables.TASKS, values, String.format(Locale.ENGLISH, "%s = ?", TaskContract.Tasks.ORIGINAL_INSTANCE_SYNC_ID),
+                    new String[] { syncId });
+        }
+        return result;
+    }
+
+
+    @Override
+    public TaskAdapter update(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
+    {
+        return mDelegate.update(db, task, isSyncAdapter);
+    }
+
+
+    @Override
+    public void delete(SQLiteDatabase db, TaskAdapter task, boolean isSyncAdapter)
+    {
+        mDelegate.delete(db, task, isSyncAdapter);
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/processors/tasks/Validating.java
@@ -145,6 +145,7 @@ public final class Validating implements EntityProcessor<TaskAdapter>
         }
 
         // only sync adapters are allowed to change the UID
+        // TODO: we probably should allow clients to set a UID on inserts
         if (!isSyncAdapter && task.isUpdated(TaskAdapter._UID))
         {
             throw new IllegalArgumentException("modification of _UID is not allowed");

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/InstanceValuesIterable.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/InstanceValuesIterable.java
@@ -20,11 +20,14 @@ import android.content.ContentValues;
 
 import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.iterators.SingletonIterator;
+import org.dmfs.jems.iterator.decorators.Mapped;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.adapters.FirstPresent;
 import org.dmfs.jems.optional.composite.Zipped;
 import org.dmfs.jems.optional.elementary.NullSafe;
+import org.dmfs.jems.optional.elementary.Present;
 import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.ValueSingle;
 import org.dmfs.provider.tasks.model.TaskAdapter;
 import org.dmfs.provider.tasks.processors.tasks.instancedata.Distant;
 import org.dmfs.provider.tasks.processors.tasks.instancedata.DueDated;
@@ -33,6 +36,7 @@ import org.dmfs.provider.tasks.processors.tasks.instancedata.Overridden;
 import org.dmfs.provider.tasks.processors.tasks.instancedata.StartDated;
 import org.dmfs.provider.tasks.processors.tasks.instancedata.VanillaInstanceData;
 import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
 
 import java.util.Iterator;
 
@@ -42,6 +46,7 @@ import java.util.Iterator;
  *
  * @author Marten Gajda
  */
+// TODO: replace Single with Generator
 public final class InstanceValuesIterable implements Iterable<Single<ContentValues>>
 {
     private final TaskAdapter mTaskAdapter;
@@ -66,10 +71,37 @@ public final class InstanceValuesIterable implements Iterable<Single<ContentValu
         Single<ContentValues> baseData = new Distant(mTaskAdapter.valueOf(TaskAdapter.IS_CLOSED) ? -1 : 0,
                 new Enduring(new DueDated(effectiveDue, new StartDated(start, new VanillaInstanceData()))));
 
-        // TODO: implement support for recurrence, for now we only return the first instance
-        return new SingletonIterator<>(mTaskAdapter.isRecurring() ?
-                new Overridden(new NullSafe<>(mTaskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_TIME)), baseData)
-                :
-                baseData);
+        if (!mTaskAdapter.isRecurring())
+        {
+            return new SingletonIterator<>(
+                    // apply the Overridden decorator only if this task has an ORIGINAL_INSTANCE_TIME
+                    new org.dmfs.provider.tasks.utils.Zipped<>(
+                            new NullSafe<>(mTaskAdapter.valueOf(TaskAdapter.ORIGINAL_INSTANCE_TIME)),
+                            baseData,
+                            (DateTime time, ContentValues data) -> new Overridden(new Present<>(time), new ValueSingle<>(data)).value()));
+        }
+
+        if (start.isPresent())
+        {
+            Optional<Duration> effectiveDuration = new FirstPresent<>(
+                    new Seq<>(
+                            new NullSafe<>(mTaskAdapter.valueOf(TaskAdapter.DURATION)),
+                            new Zipped<>(start, effectiveDue,
+                                    (dtStart, due) -> new Duration(1, 0, (int) ((due.getTimestamp() - dtStart.getTimestamp()) / 1000)))));
+
+            return new Mapped<>(dateTime -> new Distant(mTaskAdapter.valueOf(TaskAdapter.IS_CLOSED) ? -1 : 0,
+                    new Overridden(new Present<>(dateTime),
+                            new Enduring(new DueDated(new Zipped<>(new Present<>(dateTime), effectiveDuration, DateTime::addDuration),
+                                    new StartDated(new Present<>(dateTime), new VanillaInstanceData()))))),
+                    new TaskInstanceIterable(mTaskAdapter).iterator());
+        }
+
+        // special treatment for recurring tasks without a DTSTART:
+        return new Mapped<>(dateTime -> new Distant(mTaskAdapter.valueOf(TaskAdapter.IS_CLOSED) ? -1 : 0,
+                new Overridden(new Present<>(dateTime),
+                        new DueDated(new Present<>(dateTime), new VanillaInstanceData()))),
+                new TaskInstanceIterable(mTaskAdapter).iterator());
+
     }
+
 }

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TaskInstanceIterable.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TaskInstanceIterable.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import org.dmfs.jems.single.combined.Backed;
+import org.dmfs.optional.NullSafe;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.dmfs.rfc5545.recurrenceset.RecurrenceList;
+import org.dmfs.rfc5545.recurrenceset.RecurrenceRuleAdapter;
+import org.dmfs.rfc5545.recurrenceset.RecurrenceSet;
+import org.dmfs.rfc5545.recurrenceset.RecurrenceSetIterator;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} of all the instances of a task.
+ *
+ * @author Marten Gajda
+ */
+public final class TaskInstanceIterable implements Iterable<DateTime>
+{
+    private final TaskAdapter mTaskAdapter;
+
+
+    public TaskInstanceIterable(TaskAdapter taskAdapter)
+    {
+        mTaskAdapter = taskAdapter;
+    }
+
+
+    @Override
+    public Iterator<DateTime> iterator()
+    {
+        DateTime dtstart = new Backed<DateTime>(new NullSafe<>(mTaskAdapter.valueOf(TaskAdapter.DTSTART)), () -> mTaskAdapter.valueOf(TaskAdapter.DUE)).value();
+
+        RecurrenceSet set = new RecurrenceSet();
+        RecurrenceRule rule = mTaskAdapter.valueOf(TaskAdapter.RRULE);
+        if (rule != null)
+        {
+            set.addInstances(new RecurrenceRuleAdapter(rule));
+        }
+
+        set.addInstances(new RecurrenceList(toLongArray(mTaskAdapter.valueOf(TaskAdapter.RDATE))));
+        set.addExceptions(new RecurrenceList(toLongArray(mTaskAdapter.valueOf(TaskAdapter.EXDATE))));
+
+        RecurrenceSetIterator setIterator = set.iterator(dtstart.getTimeZone(), dtstart.getTimestamp(),
+                System.currentTimeMillis() + 10L * 356L * 3600L * 1000L);
+
+        return new TaskInstanceIterator(dtstart, setIterator, mTaskAdapter.valueOf(TaskAdapter.TIMEZONE_RAW));
+    }
+
+
+    private long[] toLongArray(Iterable<DateTime> dates)
+    {
+        int count = 0;
+        for (DateTime ignored : dates)
+        {
+            count += 1;
+        }
+        long[] timeStamps = new long[count];
+        int i = 0;
+        for (DateTime dt : dates)
+        {
+            timeStamps[i++] = dt.getTimestamp();
+        }
+        return timeStamps;
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TaskInstanceIterator.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/TaskInstanceIterator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import org.dmfs.iterators.AbstractBaseIterator;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.recurrenceset.RecurrenceSetIterator;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterator} of instances as returned by a {@link RecurrenceSetIterator}.
+ * <p>
+ * TODO: this should go to lib-recur
+ *
+ * @author Marten Gajda
+ */
+public final class TaskInstanceIterator extends AbstractBaseIterator<DateTime>
+{
+    private final DateTime mStart;
+    private final RecurrenceSetIterator mSetIterator;
+    private final String mTimezone;
+
+
+    TaskInstanceIterator(DateTime start, RecurrenceSetIterator setIterator, String timezone)
+    {
+        mStart = start;
+        mSetIterator = setIterator;
+        mTimezone = timezone;
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mSetIterator.hasNext();
+    }
+
+
+    @Override
+    public DateTime next()
+    {
+        DateTime result = new DateTime(mStart.getTimeZone(), mSetIterator.next());
+        return mStart.isAllDay() ? result.toAllDay() : mTimezone == null ? result.swapTimeZone(null) : result;
+    }
+}

--- a/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ContentValuesWithLong.java
+++ b/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ContentValuesWithLong.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
  * A {@link Matcher} to test if {@link ContentValues} contain a specific Long value.
  * <p>
  * TODO: can we convert that into a more generic {@link ContentValues} matcher? It might be useful in other places.
- *
+ * <p>
  * TODO: also consider moving this to "Test-Bolts"
  */
 public final class ContentValuesWithLong extends FeatureMatcher<ContentValues, Long>

--- a/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/TaskInstanceIterableTest.java
+++ b/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/TaskInstanceIterableTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.content.ContentValues;
+
+import org.dmfs.provider.tasks.model.ContentValuesTaskAdapter;
+import org.dmfs.provider.tasks.model.TaskAdapter;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TaskInstanceIterableTest
+{
+    @Test
+    public void testAbsolute() throws Exception
+    {
+        TaskAdapter taskAdapter = new ContentValuesTaskAdapter(new ContentValues());
+        taskAdapter.set(TaskAdapter.DTSTART, DateTime.parse("Europe/Berlin", "20170606T121314"));
+        taskAdapter.set(TaskAdapter.RRULE, new RecurrenceRule("FREQ=DAILY;INTERVAL=2;COUNT=10"));
+
+        assertThat(new TaskInstanceIterable(taskAdapter),
+                iteratesTo(
+                        DateTime.parse("Europe/Berlin", "20170606T121314"),
+                        DateTime.parse("Europe/Berlin", "20170608T121314"),
+                        DateTime.parse("Europe/Berlin", "20170610T121314"),
+                        DateTime.parse("Europe/Berlin", "20170612T121314"),
+                        DateTime.parse("Europe/Berlin", "20170614T121314"),
+                        DateTime.parse("Europe/Berlin", "20170616T121314"),
+                        DateTime.parse("Europe/Berlin", "20170618T121314"),
+                        DateTime.parse("Europe/Berlin", "20170620T121314"),
+                        DateTime.parse("Europe/Berlin", "20170622T121314"),
+                        DateTime.parse("Europe/Berlin", "20170624T121314")
+                ));
+    }
+
+
+    @Test
+    public void testAllDay() throws Exception
+    {
+        TaskAdapter taskAdapter = new ContentValuesTaskAdapter(new ContentValues());
+        taskAdapter.set(TaskAdapter.DTSTART, DateTime.parse("20170606"));
+        taskAdapter.set(TaskAdapter.RRULE, new RecurrenceRule("FREQ=DAILY;INTERVAL=2;COUNT=10"));
+
+        assertThat(new TaskInstanceIterable(taskAdapter),
+                iteratesTo(
+                        DateTime.parse("20170606"),
+                        DateTime.parse("20170608"),
+                        DateTime.parse("20170610"),
+                        DateTime.parse("20170612"),
+                        DateTime.parse("20170614"),
+                        DateTime.parse("20170616"),
+                        DateTime.parse("20170618"),
+                        DateTime.parse("20170620"),
+                        DateTime.parse("20170622"),
+                        DateTime.parse("20170624")
+                ));
+    }
+
+
+    @Test
+    public void testFloating() throws Exception
+    {
+        TaskAdapter taskAdapter = new ContentValuesTaskAdapter(new ContentValues());
+        taskAdapter.set(TaskAdapter.DTSTART, DateTime.parse("20170606T121314"));
+        taskAdapter.set(TaskAdapter.RRULE, new RecurrenceRule("FREQ=DAILY;INTERVAL=2;COUNT=10"));
+
+        assertThat(new TaskInstanceIterable(taskAdapter),
+                iteratesTo(
+                        DateTime.parse("20170606T121314"),
+                        DateTime.parse("20170608T121314"),
+                        DateTime.parse("20170610T121314"),
+                        DateTime.parse("20170612T121314"),
+                        DateTime.parse("20170614T121314"),
+                        DateTime.parse("20170616T121314"),
+                        DateTime.parse("20170618T121314"),
+                        DateTime.parse("20170620T121314"),
+                        DateTime.parse("20170622T121314"),
+                        DateTime.parse("20170624T121314")
+                ));
+    }
+}

--- a/opentasks/src/main/AndroidManifest.xml
+++ b/opentasks/src/main/AndroidManifest.xml
@@ -54,6 +54,10 @@
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.tasks"
                         android:scheme="content"/>
+                <data
+                        android:scheme="content"
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.instances"/>
             </intent-filter>
         </activity>
 
@@ -77,6 +81,10 @@
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.tasks"
                         android:scheme="content"/>
+                <data
+                        android:scheme="content"
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.instances"/>
             </intent-filter>
 
             <!-- Voice command "note to self" in google search -->
@@ -105,6 +113,10 @@
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.dir/org.dmfs.tasks.tasks"
                         android:scheme="content"/>
+                <data
+                        android:scheme="content"
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.dir/org.dmfs.tasks.instances"/>
             </intent-filter>
             <intent-filter android:label="@string/activity_add_task_title">
                 <action android:name="android.intent.action.INSERT_OR_EDIT"/>
@@ -119,6 +131,14 @@
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.tasks"
                         android:scheme="content"/>
+                <data
+                        android:scheme="content"
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.dir/org.dmfs.tasks.instances"/>
+                <data
+                        android:scheme="content"
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.instances"/>
             </intent-filter>
         </activity>
 
@@ -344,6 +364,10 @@
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.tasks"
                         android:scheme="content"/>
+                <data
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.instances"
+                        android:scheme="content"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="org.dmfs.android.tasks.TASK_START"/>
@@ -351,6 +375,10 @@
                 <data
                         android:host="@string/opentasks_authority"
                         android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.tasks"
+                        android:scheme="content"/>
+                <data
+                        android:host="@string/opentasks_authority"
+                        android:mimeType="vnd.android.cursor.item/org.dmfs.tasks.instances"
                         android:scheme="content"/>
             </intent-filter>
         </receiver>

--- a/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/EditTaskFragment.java
@@ -261,7 +261,8 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
                 }
             });
         }
-        mAppForEdit = !Tasks.getContentUri(mAuthority).equals(mTaskUri) && mTaskUri != null;
+        mAppForEdit = !Tasks.getContentUri(mAuthority).equals(mTaskUri) && !TaskContract.Instances.getContentUri(mAuthority)
+                .equals(mTaskUri) && mTaskUri != null;
 
         mTaskListBar = (LinearLayout) inflater.inflate(R.layout.task_list_provider_bar, mHeader);
         mListSpinner = (Spinner) mTaskListBar.findViewById(R.id.task_list_spinner);
@@ -309,6 +310,7 @@ public class EditTaskFragment extends SupportFragment implements LoaderManager.L
                 // create empty ContentSet if there was no ContentSet supplied
                 if (mValues == null)
                 {
+                    // adding a new task is always done on the Tasks table
                     mValues = new ContentSet(Tasks.getContentUri(mAuthority));
                     // ensure we start with the current time zone
                     TaskFieldAdapters.TIMEZONE.set(mValues, TimeZone.getDefault());

--- a/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/QuickAddDialogFragment.java
@@ -371,6 +371,7 @@ public class QuickAddDialogFragment extends SupportDialogFragment
         }
         else
         {
+            // add a new task on the tasks table
             task = new ContentSet(Tasks.getContentUri(mAuthority));
         }
         task.put(Tasks.LIST_ID, mListSpinner.getSelectedItemId());

--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
@@ -500,8 +500,7 @@ public class TaskListFragment extends SupportFragment
                 return;
             }
 
-            // TODO For now we get the id of the task, not the instance, once we support recurrence we'll have to change that, use instance URI that time
-            Uri taskUri = ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), (long) TaskFieldAdapters.INSTANCE_TASK_ID.get(cursor));
+            Uri taskUri = ContentUris.withAppendedId(Instances.getContentUri(mAuthority), (long) TaskFieldAdapters.TASK_ID.get(cursor));
             Color taskListColor = new ValueColor(TaskFieldAdapters.LIST_COLOR.get(cursor));
             mCallbacks.onItemSelected(taskUri, taskListColor, force, mInstancePosition);
         }
@@ -703,42 +702,38 @@ public class TaskListFragment extends SupportFragment
 
             if (cursor != null)
             {
-                // TODO: for now we get the id of the task, not the instance, once we support recurrence we'll have to change that
-                Long taskId = cursor.getLong(cursor.getColumnIndex(Instances.TASK_ID));
+                long instanceId = cursor.getLong(cursor.getColumnIndex(Instances._ID));
 
-                if (taskId != null)
+                boolean closed = cursor.getLong(cursor.getColumnIndex(Instances.IS_CLOSED)) > 0;
+                String title = cursor.getString(cursor.getColumnIndex(Instances.TITLE));
+                // TODO: use the instance URI once we support recurrence
+                Uri taskUri = ContentUris.withAppendedId(Instances.getContentUri(mAuthority), instanceId);
+
+                if (direction == FlingDetector.RIGHT_FLING)
                 {
-                    boolean closed = cursor.getLong(cursor.getColumnIndex(Instances.IS_CLOSED)) > 0;
-                    String title = cursor.getString(cursor.getColumnIndex(Instances.TITLE));
-                    // TODO: use the instance URI once we support recurrence
-                    Uri taskUri = ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), taskId);
-
-                    if (direction == FlingDetector.RIGHT_FLING)
+                    if (closed)
                     {
-                        if (closed)
-                        {
-                            removeTask(taskUri, title);
-                            // we do not know for sure if the task has been removed since the user is asked for confirmation first, so return false
+                        removeTask(taskUri, title);
+                        // we do not know for sure if the task has been removed since the user is asked for confirmation first, so return false
 
-                            return false;
+                        return false;
 
-                        }
-                        else
-                        {
-                            return setCompleteTask(taskUri, title, true);
-                        }
                     }
-                    else if (direction == FlingDetector.LEFT_FLING)
+                    else
                     {
-                        if (closed)
-                        {
-                            return setCompleteTask(taskUri, title, false);
-                        }
-                        else
-                        {
-                            openTaskEditor(taskUri, cursor.getString(cursor.getColumnIndex(Instances.ACCOUNT_TYPE)));
-                            return false;
-                        }
+                        return setCompleteTask(taskUri, title, true);
+                    }
+                }
+                else if (direction == FlingDetector.LEFT_FLING)
+                {
+                    if (closed)
+                    {
+                        return setCompleteTask(taskUri, title, false);
+                    }
+                    else
+                    {
+                        openTaskEditor(taskUri, cursor.getString(cursor.getColumnIndex(Instances.ACCOUNT_TYPE)));
+                        return false;
                     }
                 }
             }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/CancelDelayedAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/CancelDelayedAction.java
@@ -48,7 +48,7 @@ public final class CancelDelayedAction implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         ((AlarmManager) context.getSystemService(Context.ALARM_SERVICE)).cancel(
                 PendingIntent.getBroadcast(

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/CancelNotificationAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/CancelNotificationAction.java
@@ -50,7 +50,7 @@ public final class CancelNotificationAction implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri)
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri)
     {
         NotificationManagerCompat.from(context).cancel(mNotificationTag, (int) ContentUris.parseId(taskUri));
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/CompleteAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/CompleteAction.java
@@ -29,6 +29,6 @@ public final class CompleteAction extends DelegatingTaskAction
 {
     public CompleteAction()
     {
-        super(new UpdateAction((snapshot) -> new StatusData(TaskContract.Tasks.STATUS_COMPLETED)));
+        super(new UpdateAction((snapshot) -> new StatusData<>(TaskContract.Tasks.STATUS_COMPLETED)));
     }
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/Composite.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/Composite.java
@@ -50,7 +50,7 @@ public final class Composite implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         for (TaskAction action : mDelegates)
         {

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/Conditional.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/Conditional.java
@@ -34,11 +34,11 @@ import org.dmfs.tasks.contract.TaskContract;
  */
 public final class Conditional implements TaskAction
 {
-    private final BiFunction<Context, RowDataSnapshot<TaskContract.Tasks>, Boolean> mTestFunction;
+    private final BiFunction<Context, RowDataSnapshot<? extends TaskContract.TaskColumns>, Boolean> mTestFunction;
     private final TaskAction mDelegate;
 
 
-    public Conditional(BiFunction<Context, RowDataSnapshot<TaskContract.Tasks>, Boolean> testFunction, TaskAction delegate)
+    public Conditional(BiFunction<Context, RowDataSnapshot<? extends TaskContract.TaskColumns>, Boolean> testFunction, TaskAction delegate)
     {
         mTestFunction = testFunction;
         mDelegate = delegate;
@@ -46,7 +46,7 @@ public final class Conditional implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> data, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> data, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         if (mTestFunction.value(context, data))
         {

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/DeferDueAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/DeferDueAction.java
@@ -39,11 +39,11 @@ public final class DeferDueAction extends DelegatingTaskAction
             Optional<DateTime> start = new TaskDateTime(TaskContract.Tasks.DTSTART, data);
             if (start.isPresent())
             {
-                return new TimeData(start.value(), new EffectiveDueDate(data).value().addDuration(duration));
+                return new TimeData<>(start.value(), new EffectiveDueDate(data).value().addDuration(duration));
             }
             else
             {
-                return new DueData(new EffectiveDueDate(data).value().addDuration(duration));
+                return new DueData<>(new EffectiveDueDate(data).value().addDuration(duration));
             }
         }));
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/DelayedAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/DelayedAction.java
@@ -51,7 +51,7 @@ public final class DelayedAction implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         AlarmManagerCompat.setExactAndAllowWhileIdle(
                 (AlarmManager) context.getSystemService(Context.ALARM_SERVICE),

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/DelegatingTaskAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/DelegatingTaskAction.java
@@ -42,7 +42,7 @@ public abstract class DelegatingTaskAction implements TaskAction
     }
 
 
-    public final void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public final void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         mDelegate.execute(context, contentProviderClient, rowSnapshot, taskUri);
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/NotifyAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/NotifyAction.java
@@ -66,11 +66,11 @@ public final class NotifyAction implements TaskAction
     private final String GROUP_ALERTS = "org.dmfs.tasks.ALERTS";
     private final String GROUP_PINS = "org.dmfs.tasks.PINS";
 
-    private final Function<RowDataSnapshot<TaskContract.Tasks>, String> mChannelFunction;
+    private final Function<RowDataSnapshot<? extends TaskContract.TaskColumns>, String> mChannelFunction;
     private final boolean mRepost;
 
 
-    public NotifyAction(Function<RowDataSnapshot<TaskContract.Tasks>, String> channelFunction, boolean repost)
+    public NotifyAction(Function<RowDataSnapshot<? extends TaskContract.TaskColumns>, String> channelFunction, boolean repost)
     {
         mChannelFunction = channelFunction;
         mRepost = repost;
@@ -104,7 +104,7 @@ public final class NotifyAction implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> data, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> data, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         // TODO: move to central place, for now we keep it here to be sure we have created the channels
         createChannels(context);
@@ -189,7 +189,7 @@ public final class NotifyAction implements TaskAction
     }
 
 
-    private CharSequence contentText(Context context, RowDataSnapshot<TaskContract.Tasks> data)
+    private CharSequence contentText(Context context, RowDataSnapshot<TaskContract.Instances> data)
     {
         Optional<DateTime> start = new TaskStart(data);
         Optional<DateTime> due = new EffectiveDueDate(data);

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/NotifyStickyAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/NotifyStickyAction.java
@@ -30,7 +30,7 @@ import org.dmfs.tasks.contract.TaskContract;
 public final class NotifyStickyAction extends DelegatingTaskAction
 {
 
-    public NotifyStickyAction(Function<RowDataSnapshot<TaskContract.Tasks>, String> channelFunction, boolean repost)
+    public NotifyStickyAction(Function<RowDataSnapshot<? extends TaskContract.TaskColumns>, String> channelFunction, boolean repost)
     {
         super(new Conditional(
                 new NotificationEnabled(),

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/OpenAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/OpenAction.java
@@ -36,7 +36,7 @@ import org.dmfs.tasks.contract.TaskContract;
 public final class OpenAction implements TaskAction
 {
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         // TODO: check if it's still a good idea to build a custom stack
         // Creates an explicit intent for an Activity in your app

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/PersistNotificationAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/PersistNotificationAction.java
@@ -39,7 +39,7 @@ import org.json.JSONObject;
 public final class PersistNotificationAction implements TaskAction
 {
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> data, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> data, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         try
         {

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/PinAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/PinAction.java
@@ -28,6 +28,6 @@ public final class PinAction extends DelegatingTaskAction
 {
     public PinAction(boolean pin)
     {
-        super(new UpdateAction((snapshot) -> new PinnedData(pin)));
+        super(new UpdateAction((snapshot) -> new PinnedData<>(pin)));
     }
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/PostUndoAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/PostUndoAction.java
@@ -29,8 +29,8 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import android.widget.RemoteViews;
 
+import org.dmfs.android.bolts.color.colors.ResourceColor;
 import org.dmfs.android.contentpal.RowDataSnapshot;
-import org.dmfs.opentaskspal.readdata.EffectiveTaskColor;
 import org.dmfs.tasks.R;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.notification.ActionReceiver;
@@ -51,7 +51,7 @@ public final class PostUndoAction implements TaskAction
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> data, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> data, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         int id = (int) ContentUris.parseId(taskUri);
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, ActionService.CHANNEL_DUE_DATES);
@@ -84,7 +84,7 @@ public final class PostUndoAction implements TaskAction
             // don't execute this on Android 4, otherwise no notification will show up
             builder.setGroup(GROUP_UNDO);
         }
-        builder.setColor(new EffectiveTaskColor(data).argb());
+        builder.setColor(new ResourceColor(context, R.color.primary).argb());
 
         NotificationManagerCompat.from(context).notify("tasks.undo", id, builder.build());
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/TaskAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/TaskAction.java
@@ -35,5 +35,5 @@ public interface TaskAction
 {
     // TODO: consider returning an Iterable of Operations or providing a Transaction so multiple changes can be executed in a single transation
     // TODO: if we return the operation, also provide a way of executing something in case of a successful execution
-    void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException;
+    void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException;
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/UpdateAction.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/UpdateAction.java
@@ -39,17 +39,17 @@ import org.dmfs.tasks.contract.TaskContract;
  */
 public final class UpdateAction implements TaskAction
 {
-    private final Function<RowDataSnapshot<TaskContract.Tasks>, RowData<TaskContract.Tasks>> mDataFunction;
+    private final Function<RowDataSnapshot<TaskContract.Instances>, RowData<TaskContract.Instances>> mDataFunction;
 
 
-    public UpdateAction(Function<RowDataSnapshot<TaskContract.Tasks>, RowData<TaskContract.Tasks>> dataFunction)
+    public UpdateAction(Function<RowDataSnapshot<TaskContract.Instances>, RowData<TaskContract.Instances>> dataFunction)
     {
         mDataFunction = dataFunction;
     }
 
 
     @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Tasks> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
     {
         new BaseTransaction().with(new Seq<>(new Update<>(new RowUriReference<>(taskUri), mDataFunction.value(rowSnapshot)))).commit(contentProviderClient);
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/actions/conditions/NotificationEnabled.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/actions/conditions/NotificationEnabled.java
@@ -30,10 +30,10 @@ import org.dmfs.tasks.contract.TaskContract;
 /**
  * @author Marten Gajda
  */
-public final class NotificationEnabled implements BiFunction<Context, RowDataSnapshot<TaskContract.Tasks>, Boolean>
+public final class NotificationEnabled implements BiFunction<Context, RowDataSnapshot<? extends TaskContract.TaskColumns>, Boolean>
 {
     @Override
-    public Boolean value(Context context, RowDataSnapshot<TaskContract.Tasks> snapshot)
+    public Boolean value(Context context, RowDataSnapshot<? extends TaskContract.TaskColumns> snapshot)
     {
         if (Build.VERSION.SDK_INT >= 26)
         {

--- a/opentasks/src/main/java/org/dmfs/tasks/dashclock/TasksExtension.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/dashclock/TasksExtension.java
@@ -168,7 +168,7 @@ public class TasksExtension extends DashClockExtension
 
                 // intent
                 String accountType = c.getString(c.getColumnIndex(Instances.ACCOUNT_TYPE));
-                Long taskId = c.getLong(c.getColumnIndex(Instances.TASK_ID));
+                long taskId = c.getLong(c.getColumnIndex(Instances._ID));
                 Intent clickIntent = buildClickIntent(taskId, accountType);
 
                 // Publish the extension data update.
@@ -310,10 +310,10 @@ public class TasksExtension extends DashClockExtension
     }
 
 
-    protected Intent buildClickIntent(long taskId, String accountType)
+    protected Intent buildClickIntent(long instanceId, String accountType)
     {
         Intent clickIntent = new Intent(Intent.ACTION_VIEW);
-        clickIntent.setData(ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), taskId));
+        clickIntent.setData(ContentUris.withAppendedId(Instances.getContentUri(mAuthority), instanceId));
         clickIntent.putExtra(EditTaskActivity.EXTRA_DATA_ACCOUNT_TYPE, accountType);
 
         return clickIntent;

--- a/opentasks/src/main/java/org/dmfs/tasks/groupings/ByDueDate.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/groupings/ByDueDate.java
@@ -303,6 +303,7 @@ public class ByDueDate extends AbstractGroupingFactory
     }
 
 
+
     @Override
     ExpandableGroupDescriptor makeExpandableGroupDescriptor(String authority)
     {

--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetItem.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetItem.java
@@ -44,9 +44,9 @@ public class TaskListWidgetItem
     private final int mTaskColor;
 
     /**
-     * The task ID.
+     * The instance ID.
      */
-    private final int mTaskId;
+    private final int mInstanceId;
 
     /**
      * The flag to indicate if task is closed.
@@ -70,7 +70,7 @@ public class TaskListWidgetItem
      */
     public TaskListWidgetItem(int id, String title, Time due, int color, boolean isClosed)
     {
-        mTaskId = id;
+        mInstanceId = id;
         mTaskTitle = title;
         mDueDate = due;
         mTaskColor = color;
@@ -116,9 +116,9 @@ public class TaskListWidgetItem
      *
      * @return the task id
      */
-    public long getTaskId()
+    public long getInstanceId()
     {
-        return mTaskId;
+        return mInstanceId;
     }
 
 

--- a/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/homescreen/TaskListWidgetUpdaterService.java
@@ -35,7 +35,6 @@ import org.dmfs.provider.tasks.AuthorityUtil;
 import org.dmfs.tasks.R;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Instances;
-import org.dmfs.tasks.contract.TaskContract.Tasks;
 import org.dmfs.tasks.model.TaskFieldAdapters;
 import org.dmfs.tasks.utils.DateFormatter;
 import org.dmfs.tasks.utils.DateFormatter.DateFormatContext;
@@ -250,7 +249,7 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
                 row.setTextViewText(android.R.id.text1, null);
             }
 
-            Uri taskUri = ContentUris.withAppendedId(Tasks.getContentUri(mAuthority), items[position].getTaskId());
+            Uri taskUri = ContentUris.withAppendedId(Instances.getContentUri(mAuthority), items[position].getInstanceId());
             Intent i = new Intent();
             i.setData(taskUri);
             row.setOnClickFillInIntent(R.id.widget_list_item, i);
@@ -363,7 +362,7 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
 
                 while (mTasksCursor.moveToNext())
                 {
-                    items[itemIndex] = new TaskListWidgetItem(TaskFieldAdapters.INSTANCE_TASK_ID.get(mTasksCursor), TaskFieldAdapters.TITLE.get(mTasksCursor),
+                    items[itemIndex] = new TaskListWidgetItem(TaskFieldAdapters.TASK_ID.get(mTasksCursor), TaskFieldAdapters.TITLE.get(mTasksCursor),
                             TaskFieldAdapters.DUE.get(mTasksCursor), TaskFieldAdapters.LIST_COLOR.get(mTasksCursor),
                             TaskFieldAdapters.IS_CLOSED.get(mTasksCursor));
                     itemIndex++;
@@ -395,6 +394,7 @@ public class TaskListWidgetUpdaterService extends RemoteViewsService
                         + TaskContract.Instances.INSTANCE_START + "<=" + System.currentTimeMillis() + " OR " + TaskContract.Instances.INSTANCE_START
                         + " is null OR " + TaskContract.Instances.INSTANCE_START + " = " + TaskContract.Instances.INSTANCE_DUE + " )");
 
+                selection.append(" AND ").append(Instances.DISTANCE_FROM_CURRENT).append(" <=0 ");
                 if (lists != null && !lists.isEmpty())
                 {
                     selection.append(" AND ( ");

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/ActionService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/ActionService.java
@@ -25,7 +25,6 @@ import android.net.Uri;
 import android.os.RemoteException;
 import android.util.Log;
 
-import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.predicates.EqArg;
 import org.dmfs.android.contentpal.rowsets.QueryRowSet;
@@ -37,7 +36,7 @@ import org.dmfs.opentaskspal.readdata.TaskPin;
 import org.dmfs.opentaskspal.readdata.TaskStart;
 import org.dmfs.opentaskspal.readdata.TaskTitle;
 import org.dmfs.opentaskspal.readdata.TaskVersion;
-import org.dmfs.opentaskspal.views.TasksView;
+import org.dmfs.opentaskspal.views.InstancesView;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 import org.dmfs.tasks.JobIds;
@@ -107,15 +106,15 @@ public final class ActionService extends JobIntentService
     {
         try
         {
-            Uri taskUri = intent.getData();
-            if (taskUri == null || taskUri.getAuthority() == null)
+            Uri instanceUri = intent.getData();
+            if (instanceUri == null || instanceUri.getAuthority() == null)
             {
-                throw new RuntimeException(String.format("Invalid task Uri %s", taskUri));
+                throw new RuntimeException(String.format("Invalid task instance Uri %s", instanceUri));
             }
 
-            ContentProviderClient contentProviderClient = getContentResolver().acquireContentProviderClient(taskUri);
-            for (RowSnapshot<TaskContract.Tasks> snapshot : new QueryRowSet<>(
-                    new TasksView(taskUri.getAuthority(), contentProviderClient),
+            ContentProviderClient contentProviderClient = getContentResolver().acquireContentProviderClient(instanceUri);
+            for (RowSnapshot<TaskContract.Instances> snapshot : new QueryRowSet<>(
+                    new InstancesView<>(instanceUri.getAuthority(), contentProviderClient),
                     new org.dmfs.android.contentpal.projections.Composite<>(
                             Id.PROJECTION,
                             EffectiveDueDate.PROJECTION,
@@ -125,9 +124,9 @@ public final class ActionService extends JobIntentService
                             TaskTitle.PROJECTION,
                             TaskVersion.PROJECTION,
                             TaskIsClosed.PROJECTION),
-                    new EqArg(TaskContract.Tasks._ID, ContentUris.parseId(taskUri))))
+                    new EqArg(TaskContract.Instances._ID, ContentUris.parseId(instanceUri))))
             {
-                resolveAction(intent.getAction()).execute(this, contentProviderClient, snapshot.values(), taskUri);
+                resolveAction(intent.getAction()).execute(this, contentProviderClient, snapshot.values(), instanceUri);
             }
         }
         catch (RuntimeException | RemoteException | OperationApplicationException e)

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/state/PrefState.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/state/PrefState.java
@@ -48,7 +48,7 @@ public final class PrefState implements TaskNotificationState
 
     @NonNull
     @Override
-    public Uri task()
+    public Uri instance()
     {
         return Uri.parse(mEntry.getKey());
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/state/RowState.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/state/RowState.java
@@ -35,10 +35,10 @@ import androidx.annotation.NonNull;
 public final class RowState implements TaskNotificationState
 {
     private final String mAuthority;
-    private final RowDataSnapshot<TaskContract.Tasks> mRow;
+    private final RowDataSnapshot<? extends TaskContract.Instances> mRow;
 
 
-    public RowState(@NonNull String authority, @NonNull RowDataSnapshot<TaskContract.Tasks> row)
+    public RowState(@NonNull String authority, @NonNull RowDataSnapshot<? extends TaskContract.Instances> row)
     {
         mAuthority = authority;
         mRow = row;
@@ -47,9 +47,9 @@ public final class RowState implements TaskNotificationState
 
     @NonNull
     @Override
-    public Uri task()
+    public Uri instance()
     {
-        return ContentUris.withAppendedId(TaskContract.Tasks.getContentUri(mAuthority), new Id(mRow).value());
+        return ContentUris.withAppendedId(TaskContract.Instances.getContentUri(mAuthority), new Id(mRow).value());
     }
 
 

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/state/RowStateInfo.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/state/RowStateInfo.java
@@ -36,10 +36,10 @@ import androidx.annotation.NonNull;
  */
 public final class RowStateInfo implements StateInfo
 {
-    private final RowDataSnapshot<TaskContract.Tasks> mRow;
+    private final RowDataSnapshot<? extends TaskContract.Instances> mRow;
 
 
-    public RowStateInfo(@NonNull RowDataSnapshot<TaskContract.Tasks> row)
+    public RowStateInfo(@NonNull RowDataSnapshot<? extends TaskContract.Instances> row)
     {
         mRow = row;
     }

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/state/TaskNotificationState.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/state/TaskNotificationState.java
@@ -30,8 +30,7 @@ import androidx.annotation.NonNull;
  */
 public interface TaskNotificationState
 {
-    @NonNull
-    Uri task();
+    Uri instance();
 
     int taskVersion();
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveDueDate.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveDueDate.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.android.contentpal.projections.Composite;
+import org.dmfs.android.contentpal.projections.Joined;
 import org.dmfs.android.contentpal.projections.MultiProjection;
 import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.jems.optional.Optional;
@@ -28,6 +29,7 @@ import org.dmfs.jems.optional.adapters.FirstPresent;
 import org.dmfs.jems.optional.composite.Zipped;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -39,13 +41,14 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class EffectiveDueDate extends DelegatingOptional<DateTime>
 {
-    public static final Projection<Tasks> PROJECTION = new Composite<>(
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new Composite<>(
             new MultiProjection<>(Tasks.DUE, Tasks.DTSTART),
-            TaskDateTime.PROJECTION,
+            // TODO: figure out how to get rid of Joined here
+            new Joined<>(TaskDateTime.PROJECTION),
             TaskDuration.PROJECTION);
 
 
-    public EffectiveDueDate(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public EffectiveDueDate(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new FirstPresent<>(
                 new Seq<>(

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveTaskColor.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveTaskColor.java
@@ -38,10 +38,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class EffectiveTaskColor extends DelegatingColor
 {
-    public static final Projection<Tasks> PROJECTION = new MultiProjection<>(Tasks.TASK_COLOR, Tasks.LIST_COLOR);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new MultiProjection<>(Tasks.TASK_COLOR, Tasks.LIST_COLOR);
 
 
-    public EffectiveTaskColor(@NonNull RowDataSnapshot<TaskContract.Tasks> rowData)
+    public EffectiveTaskColor(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(new SingleColor(
                 new Backed<Color>(

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveTimezone.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveTimezone.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
 import org.dmfs.jems.single.elementary.ValueSingle;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 import java.util.TimeZone;
@@ -37,10 +38,10 @@ import java.util.TimeZone;
  */
 public final class EffectiveTimezone extends DelegatingSingle<TimeZone>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.TZ);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.TZ);
 
 
-    public EffectiveTimezone(@NonNull RowDataSnapshot<Tasks> rowData)
+    public EffectiveTimezone(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(new ValueSingle<>(rowData.data(Tasks.TZ, TimeZone::getTimeZone).value()));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/Id.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/Id.java
@@ -17,7 +17,6 @@
 package org.dmfs.opentaskspal.readdata;
 
 import android.provider.BaseColumns;
-import androidx.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowDataSnapshot;
@@ -25,6 +24,8 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
 import org.dmfs.jems.single.elementary.ValueSingle;
+
+import androidx.annotation.NonNull;
 
 
 /**

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/PercentComplete.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/PercentComplete.java
@@ -23,6 +23,7 @@ import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -33,10 +34,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class PercentComplete extends DelegatingOptional<Integer>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.PERCENT_COMPLETE);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.PERCENT_COMPLETE);
 
 
-    public PercentComplete(@NonNull RowDataSnapshot<Tasks> rowData)
+    public PercentComplete(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(rowData.data(Tasks.PERCENT_COMPLETE, Integer::valueOf));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskCompletionTime.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskCompletionTime.java
@@ -26,6 +26,7 @@ import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.jems.optional.decorators.Mapped;
 import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -36,12 +37,12 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskCompletionTime extends DelegatingOptional<DateTime>
 {
-    public static final Projection<Tasks> PROJECTION = new Composite<>(
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new Composite<>(
             new SingleColProjection<>(Tasks.COMPLETED),
             EffectiveTimezone.PROJECTION);
 
 
-    public TaskCompletionTime(@NonNull final RowDataSnapshot<Tasks> rowData)
+    public TaskCompletionTime(@NonNull final RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(new Mapped<>(
                 timeStamp -> new DateTime(timeStamp).shiftTimeZone(new EffectiveTimezone(rowData).value()),

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskDateTime.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskDateTime.java
@@ -27,6 +27,7 @@ import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.jems.optional.decorators.Mapped;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -38,12 +39,12 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskDateTime extends DelegatingOptional<DateTime>
 {
-    public static final Projection<Tasks> PROJECTION = new Composite<>(
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new Composite<>(
             new MultiProjection<>(Tasks.DTSTART, Tasks.DUE, Tasks.COMPLETED, Tasks.IS_ALLDAY),
             EffectiveTimezone.PROJECTION);
 
 
-    public TaskDateTime(@NonNull String columnName, @NonNull final RowDataSnapshot<Tasks> rowData)
+    public TaskDateTime(@NonNull String columnName, @NonNull final RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(new Mapped<>(
                 (Long timeStamp) -> new Backed<>(rowData.data(Tasks.IS_ALLDAY, "1"::equals), false).value() ?

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskDuration.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskDuration.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.rfc5545.Duration;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -34,10 +35,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskDuration extends DelegatingOptional<Duration>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.DURATION);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.DURATION);
 
 
-    public TaskDuration(@NonNull RowDataSnapshot<Tasks> rowData)
+    public TaskDuration(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowData)
     {
         super(rowData.data(Tasks.DURATION, Duration::parse));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskIsClosed.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskIsClosed.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -34,10 +35,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskIsClosed extends DelegatingSingle<Boolean>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.IS_CLOSED);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.IS_CLOSED);
 
 
-    public TaskIsClosed(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskIsClosed(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new Backed<>(rowDataSnapshot.data(Tasks.IS_CLOSED, "1"::equals), false));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskPin.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskPin.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -34,10 +35,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskPin extends DelegatingSingle<Boolean>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.PINNED);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.PINNED);
 
 
-    public TaskPin(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskPin(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new Backed<Boolean>(rowDataSnapshot.data(Tasks.PINNED, "1"::equals), false));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskStart.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskStart.java
@@ -25,6 +25,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.rfc5545.DateTime;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -35,10 +36,11 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskStart extends DelegatingOptional<DateTime>
 {
-    public static final Projection<Tasks> PROJECTION = new Composite<>(new SingleColProjection<>(Tasks.DTSTART), TaskDateTime.PROJECTION);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION =
+            new Composite<>(new SingleColProjection<>(Tasks.DTSTART), TaskDateTime.PROJECTION);
 
 
-    public TaskStart(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskStart(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new TaskDateTime(Tasks.DTSTART, rowDataSnapshot));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskStatus.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskStatus.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -34,10 +35,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskStatus extends DelegatingSingle<Integer>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.STATUS);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.STATUS);
 
 
-    public TaskStatus(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskStatus(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new Backed<>(rowDataSnapshot.data(Tasks.STATUS, Integer::parseInt), Tasks.STATUS_DEFAULT));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskTitle.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskTitle.java
@@ -23,6 +23,7 @@ import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -33,10 +34,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskTitle extends DelegatingOptional<CharSequence>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.TITLE);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.TITLE);
 
 
-    public TaskTitle(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskTitle(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(rowDataSnapshot.data(Tasks.TITLE, s -> s));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskUri.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskUri.java
@@ -18,12 +18,15 @@ package org.dmfs.opentaskspal.readdata;
 
 import android.content.ContentUris;
 import android.net.Uri;
-import androidx.annotation.NonNull;
+import android.provider.BaseColumns;
 
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.jems.single.Single;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -33,13 +36,13 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskUri implements Single<Uri>
 {
-    public static final Projection<?> PROJECTION = Id.PROJECTION;
+    public static final Projection<? super BaseColumns> PROJECTION = Id.PROJECTION;
 
-    private final RowDataSnapshot<Tasks> mRowDataSnapshot;
+    private final RowDataSnapshot<? extends TaskContract.TaskColumns> mRowDataSnapshot;
     private final String mAuthority;
 
 
-    public TaskUri(@NonNull String authority, @NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskUri(@NonNull String authority, @NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         mAuthority = authority;
         mRowDataSnapshot = rowDataSnapshot;

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskVersion.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/TaskVersion.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.jems.single.decorators.DelegatingSingle;
+import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 
 
@@ -34,10 +35,10 @@ import org.dmfs.tasks.contract.TaskContract.Tasks;
  */
 public final class TaskVersion extends DelegatingSingle<Integer>
 {
-    public static final Projection<Tasks> PROJECTION = new SingleColProjection<>(Tasks.VERSION);
+    public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new SingleColProjection<>(Tasks.VERSION);
 
 
-    public TaskVersion(@NonNull RowDataSnapshot<Tasks> rowDataSnapshot)
+    public TaskVersion(@NonNull RowDataSnapshot<? extends TaskContract.TaskColumns> rowDataSnapshot)
     {
         super(new Backed<>(rowDataSnapshot.data(Tasks.VERSION, Integer::parseInt), 0));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/DueData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/DueData.java
@@ -30,7 +30,7 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Gabor Keszthelyi
  */
-public final class DueData implements RowData<TaskContract.Tasks>
+public final class DueData<T extends TaskContract.TaskColumns> implements RowData<T>
 {
     private final DateTime mDue;
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/OriginalInstanceData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/OriginalInstanceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2018 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,28 @@
 
 package org.dmfs.opentaskspal.tasks;
 
-import androidx.annotation.NonNull;
-
 import org.dmfs.android.contentpal.RowData;
-import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
+import org.dmfs.android.contentpal.rowdata.Referring;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.tasks.contract.TaskContract;
 
+import androidx.annotation.NonNull;
+
 
 /**
- * {@link RowData} for adding {@link TaskContract.Tasks#ORIGINAL_INSTANCE_SYNC_ID}
+ * {@link RowData} of an instance override.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
-public final class OriginalInstanceSyncIdData extends DelegatingRowData<TaskContract.Tasks>
+public final class OriginalInstanceData extends DelegatingRowData<TaskContract.Tasks>
 {
-    public OriginalInstanceSyncIdData(@NonNull CharSequence originalInstanceSyncId, DateTime originalTime)
+    public OriginalInstanceData(@NonNull RowSnapshot originalTask, DateTime originalTime)
     {
-        // TODO CharSequenceRowData allows null so this class wouldn't fail with that but erase the value
         super(new Composite<>(
-                new CharSequenceRowData<>(TaskContract.Tasks.ORIGINAL_INSTANCE_SYNC_ID, originalInstanceSyncId),
+                new Referring<>(TaskContract.Tasks.ORIGINAL_INSTANCE_ID, originalTask),
                 (transactionContext, builder) -> builder.withValue(TaskContract.Tasks.ORIGINAL_INSTANCE_TIME, originalTime.getTimestamp())));
     }
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/PinnedData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/PinnedData.java
@@ -29,7 +29,7 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Marten Gajda
  */
-public final class PinnedData implements RowData<TaskContract.Tasks>
+public final class PinnedData<T extends TaskContract.TaskColumns> implements RowData<T>
 {
     private final boolean mPinned;
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/StatusData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/StatusData.java
@@ -29,7 +29,7 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Marten Gajda
  */
-public final class StatusData implements RowData<TaskContract.Tasks>
+public final class StatusData<T extends TaskContract.TaskColumns> implements RowData<T>
 {
     private final int mStatus;
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/TimeData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/TimeData.java
@@ -34,7 +34,7 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Gabor Keszthelyi
  */
-public final class TimeData implements RowData<TaskContract.Tasks>
+public final class TimeData<T extends TaskContract.TaskColumns> implements RowData<T>
 {
     private final DateTime mStart;
     private final Optional<DateTime> mDue;

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/views/InstancesView.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/views/InstancesView.java
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package org.dmfs.tasks.actions;
+package org.dmfs.opentaskspal.views;
 
 import android.content.ContentProviderClient;
-import android.content.Context;
-import android.content.OperationApplicationException;
-import android.net.Uri;
-import android.os.RemoteException;
 
-import org.dmfs.android.contentpal.RowDataSnapshot;
-import org.dmfs.tasks.actions.utils.NotificationPrefs;
+import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.views.BaseView;
+import org.dmfs.android.contentpal.views.DelegatingView;
 import org.dmfs.tasks.contract.TaskContract;
 
 
 /**
- * A {@link TaskAction} which removes a notification from the preferences.
+ * {@link View} for the {@link TaskContract.Instances} table.
  *
  * @author Marten Gajda
  */
-public final class RemoveNotificationAction implements TaskAction
+public final class InstancesView<T extends TaskContract.Instances> extends DelegatingView<T>
 {
-    @Override
-    public void execute(Context context, ContentProviderClient contentProviderClient, RowDataSnapshot<TaskContract.Instances> rowSnapshot, Uri taskUri) throws RemoteException, OperationApplicationException
+    public InstancesView(String authority, ContentProviderClient client)
     {
-        new NotificationPrefs(context).next().edit().remove(taskUri.toString()).apply();
+        super(new BaseView<>(client, TaskContract.Instances.getContentUri(authority)));
     }
 }

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/DueDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/DueDataTest.java
@@ -47,7 +47,7 @@ public final class DueDataTest
     {
         DateTime due = DateTime.now();
 
-        assertThat(new DueData(due),
+        assertThat(new DueData<>(due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DUE, due.getTimestamp()),
@@ -70,7 +70,7 @@ public final class DueDataTest
     {
         DateTime due = DateTime.now().shiftTimeZone(TimeZone.getTimeZone("GMT+4"));
 
-        assertThat(new DueData(due),
+        assertThat(new DueData<>(due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DUE, due.getTimestamp()),
@@ -93,7 +93,7 @@ public final class DueDataTest
     {
         DateTime due = DateTime.now().toAllDay();
 
-        assertThat(new DueData(due),
+        assertThat(new DueData<>(due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DUE, due.getTimestamp()),

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/OriginalInstanceSyncIdDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/OriginalInstanceSyncIdDataTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.opentaskspal.tasks;
 
+import org.dmfs.rfc5545.DateTime;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,10 +41,11 @@ public final class OriginalInstanceSyncIdDataTest
     @Test
     public void test_thatOriginalSyncIdIsAdded()
     {
-        assertThat(new OriginalInstanceSyncIdData("test"),
+        assertThat(new OriginalInstanceSyncIdData("test", DateTime.parse("20180103")),
                 builds(
                         withValuesOnly(
-                                containing(Tasks.ORIGINAL_INSTANCE_SYNC_ID, "test")
+                                containing(Tasks.ORIGINAL_INSTANCE_SYNC_ID, "test"),
+                                containing(Tasks.ORIGINAL_INSTANCE_TIME, DateTime.parse("20180103").getTimestamp())
                         )));
     }
 

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/TimeDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/TimeDataTest.java
@@ -52,7 +52,7 @@ public final class TimeDataTest
         DateTime start = DateTime.now();
         DateTime due = start.addDuration(new Duration(1, 1, 0));
 
-        assertThat(new TimeData(start, due),
+        assertThat(new TimeData<>(start, due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DTSTART, start.getTimestamp()),
@@ -76,7 +76,7 @@ public final class TimeDataTest
         DateTime start = DateTime.now();
         Duration duration = new Duration(1, 3, 0);
 
-        assertThat(new TimeData(start, duration),
+        assertThat(new TimeData<>(start, duration),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DTSTART, start.getTimestamp()),
@@ -99,7 +99,7 @@ public final class TimeDataTest
     {
         DateTime start = DateTime.now();
 
-        assertThat(new TimeData(start),
+        assertThat(new TimeData<>(start),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DTSTART, start.getTimestamp()),
@@ -120,7 +120,7 @@ public final class TimeDataTest
     @Test(expected = IllegalArgumentException.class)
     public void test_whenStartIsAllDayAndDueIsNot_throwsIllegalArgument()
     {
-        new TimeData(DateTime.now().toAllDay(), DateTime.now())
+        new TimeData<>(DateTime.now().toAllDay(), DateTime.now())
                 .updatedBuilder(mock(TransactionContext.class), mock(ContentProviderOperation.Builder.class));
     }
 
@@ -128,7 +128,7 @@ public final class TimeDataTest
     @Test(expected = IllegalArgumentException.class)
     public void test_whenDueIsAllDayAndStartIsNot_throwsIllegalArgument()
     {
-        new TimeData(DateTime.now(), DateTime.now().toAllDay())
+        new TimeData<>(DateTime.now(), DateTime.now().toAllDay())
                 .updatedBuilder(mock(TransactionContext.class), mock(ContentProviderOperation.Builder.class));
     }
 
@@ -141,7 +141,7 @@ public final class TimeDataTest
 
         DateTime startExpected = start.shiftTimeZone(TimeZone.getTimeZone("GMT+6"));
 
-        assertThat(new TimeData(start, due),
+        assertThat(new TimeData<>(start, due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DTSTART, startExpected.getTimestamp()),
@@ -165,7 +165,7 @@ public final class TimeDataTest
         DateTime start = DateTime.now().toAllDay();
         DateTime due = start.addDuration(new Duration(1, 3, 0));
 
-        assertThat(new TimeData(start, due),
+        assertThat(new TimeData<>(start, due),
                 builds(
                         withValuesOnly(
                                 containing(Tasks.DTSTART, start.getTimestamp()),


### PR DESCRIPTION
This commit adds initial recurrence support in that recurring instances are handled correctly when instances are edited or deleted.
In order to support this, the UI now operates on the Instances table rather then the tasks table. The instances table now supports deletes, and updates like the tasks table with the difference that all these operations only affect the specific instance that's addressed. All the operations on the instances table are converted into operations on a task by creating exception instances and rdates or exdates.

Inserting instances is currently not possible because only a fixed number of instances are expanded. This means an instance inserted beyond the expansion window would still not show up in the instances table.
See https://github.com/dmfs/opentasks/issues/741

There is still room for improvement in that we could split of completed tasks and modify recurrence rules when delting instances from the start or end of the series. That's left to future updates.
Also there is no UI yet to create or edit recurrence properties itself.

At present there is only one upcoming instance expanded, so you can only see the "current" instance (and all completed ones). This may/will change in future but may require some UI changes as well.

In order to support this commit a number of tests have been implemented which test creating and altering recurring instances.

Currently an exception is created when a recurring instance is modified which wasn't an exception before. This approach is RFC 5545 compliant but not supported by Apple clients. This will be fixed in future updates.