### PR TITLE
Send out PROVIDER_CHANGED broadcasts again, fixes #822

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
-def jems_version = '1.23'
+def jems_version = '1.24'
 def contentpal_version = '0.5'
 def androidx_test_runner_version = '1.1.1'
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/TaskProvider.java
@@ -1317,15 +1317,8 @@ public final class TaskProvider extends SQLiteContentProvider implements OnAccou
         super.onEndTransaction(callerIsSyncAdapter);
         if (mChanged.compareAndSet(true, false))
         {
-            Intent providerChangedIntent = new Intent(Intent.ACTION_PROVIDER_CHANGED, TaskContract.getContentUri(mAuthority));
             updateNotifications();
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            {
-                // for now we only notify our own package
-                // we'll have to figure out how to do this correctly on Android 8+, e.g. how is it done by CalendarProvider and ContactsProvider
-                providerChangedIntent.setPackage(getContext().getPackageName());
-            }
-            getContext().sendBroadcast(providerChangedIntent);
+            Utils.sendActionProviderChangedBroadCast(getContext(), mAuthority);
         }
 
         if (Boolean.TRUE.equals(mStaleListCreated.get()))

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ResourceArray.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ResourceArray.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.content.Context;
+
+import org.dmfs.iterators.elementary.Seq;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} of a string array resource.
+ *
+ * @author Marten Gajda
+ */
+public final class ResourceArray implements Iterable<String>
+{
+    private final Context mContext;
+    private final int mResource;
+
+
+    public ResourceArray(Context context, int resource)
+    {
+        mContext = context;
+        mResource = resource;
+    }
+
+
+    @Override
+    public Iterator<String> iterator()
+    {
+        return new Seq<>(mContext.getResources().getStringArray(mResource));
+    }
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/With.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/With.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import org.dmfs.jems.procedure.Procedure;
+import org.dmfs.jems.single.Single;
+
+
+/**
+ * Experiemental Procedure which calls another procedure with a given value.
+ * <p>
+ * TODO move to jems if this works out well
+ *
+ * @author Marten Gajda
+ */
+@Deprecated
+public final class With<T> implements Procedure<Procedure<T>>
+{
+    private final Single<T> mValue;
+
+
+    public With(T value)
+    {
+        this(() -> value);
+    }
+
+
+    public With(Single<T> value)
+    {
+        mValue = value;
+    }
+
+
+    @Override
+    public void process(Procedure<T> delegate)
+    {
+        delegate.process(mValue.value());
+    }
+}

--- a/opentasks-provider/src/main/res/values/opentasks_provider_changed_receivers.xml
+++ b/opentasks-provider/src/main/res/values/opentasks_provider_changed_receivers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="opentasks_provider_changed_receivers">
+        <item>org.andstatus.todoagenda</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Since Android 8 it's not possible to listen to implicit broadcasts anymore when the receiver is declared in the AndroidManifest.xml.
In a previous commit we disabled sending out broadcasts to other apps. This caused some trouble.
For new we hard code 3rd party receiver package names in a resource array. This is supposed to be changed later on, see #824.