### PR TITLE
Don't perform noop updates, implements #836

### DIFF
--- a/opentasks-provider/build.gradle
+++ b/opentasks-provider/build.gradle
@@ -43,4 +43,8 @@ dependencies {
     androidTestImplementation deps.support_annotations
     androidTestImplementation deps.support_test_runner
     androidTestImplementation deps.support_test_rules
+    androidTestImplementation deps.mockito
+    androidTestImplementation deps.jems_testing
+    androidTestImplementation deps.hamcrest
+    androidTestImplementation deps.contentpal_testing
 }

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderObserverTest.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/TaskProviderObserverTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks;
+
+import android.accounts.Account;
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.content.OperationApplicationException;
+import android.os.Build;
+import android.os.RemoteException;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.OperationsQueue;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.operations.BulkDelete;
+import org.dmfs.android.contentpal.operations.Put;
+import org.dmfs.android.contentpal.queues.BasicOperationsQueue;
+import org.dmfs.android.contentpal.rowsnapshots.VirtualRowSnapshot;
+import org.dmfs.android.contentpal.tables.Synced;
+import org.dmfs.android.contenttestpal.operations.AssertEmptyTable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.opentaskspal.tables.InstanceTable;
+import org.dmfs.opentaskspal.tables.LocalTaskListsTable;
+import org.dmfs.opentaskspal.tables.TaskListScoped;
+import org.dmfs.opentaskspal.tables.TaskListsTable;
+import org.dmfs.opentaskspal.tables.TasksTable;
+import org.dmfs.opentaskspal.tasklists.NameData;
+import org.dmfs.opentaskspal.tasks.TitleData;
+import org.dmfs.tasks.contract.TaskContract;
+import org.dmfs.tasks.contract.TaskContract.TaskLists;
+import org.dmfs.tasks.contract.TaskContract.Tasks;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import static org.dmfs.android.contentpal.testing.android.uri.UriMatcher.hasParam;
+import static org.dmfs.provider.tasks.matchers.NotifiesMatcher.notifies;
+import static org.dmfs.provider.tasks.matchers.UriMatcher.authority;
+import static org.dmfs.provider.tasks.matchers.UriMatcher.path;
+import static org.dmfs.provider.tasks.matchers.UriMatcher.scheme;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+
+/**
+ * Tests for {@link TaskProvider}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(AndroidJUnit4.class)
+public class TaskProviderObserverTest
+{
+    private String mAuthority;
+    private Context mContext;
+    private ContentProviderClient mClient;
+    private final Account testAccount = new Account("foo", "bar");
+
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mContext = InstrumentationRegistry.getTargetContext();
+        mAuthority = AuthorityUtil.taskAuthority(mContext);
+        mClient = mContext.getContentResolver().acquireContentProviderClient(mAuthority);
+
+        // Assert that tables are empty:
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new Seq<Operation<?>>(
+                new AssertEmptyTable<>(new TasksTable(mAuthority)),
+                new AssertEmptyTable<>(new TaskListsTable(mAuthority)),
+                new AssertEmptyTable<>(new InstanceTable(mAuthority))));
+        queue.flush();
+    }
+
+
+    @After
+    public void tearDown() throws Exception
+    {
+        /*
+        TODO When Test Orchestration is available, there will be no need for clean up here and check in setUp(), every test method will run in separate instrumentation
+        https://android-developers.googleblog.com/2017/07/android-testing-support-library-10-is.html
+        https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator
+        */
+
+        // Clear the DB:
+        BasicOperationsQueue queue = new BasicOperationsQueue(mClient);
+        queue.enqueue(new Seq<Operation<?>>(
+                new BulkDelete<>(new LocalTaskListsTable(mAuthority)),
+                new BulkDelete<>(new Synced<>(testAccount, new TaskListsTable(mAuthority)))));
+        queue.flush();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            mClient.close();
+        }
+        else
+        {
+            mClient.release();
+        }
+    }
+
+
+    /**
+     * Test notifications for creating one task list and task.
+     */
+    @Test
+    public void testSingleInsert() throws RemoteException, OperationApplicationException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        assertThat(new Seq<>(
+                        new Put<>(taskList, new NameData("list1")),
+                        new Put<>(task, new TitleData("task1"))),
+                notifies(
+                        TaskContract.getContentUri(mAuthority),
+                        queue,
+                        containsInAnyOrder(
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(is("/tasks"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(startsWith("/tasks/"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(startsWith("/instances"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(startsWith("/tasklists/"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(is("/tasklists")),
+                                        hasParam(TaskContract.CALLER_IS_SYNCADAPTER, "true"),
+                                        hasParam(TaskContract.ACCOUNT_NAME, TaskContract.LOCAL_ACCOUNT_NAME),
+                                        hasParam(TaskContract.ACCOUNT_TYPE, TaskContract.LOCAL_ACCOUNT_TYPE)
+                                ))));
+    }
+
+
+    /**
+     * Update a task and check the notifications.
+     */
+    @Test
+    public void testSingleUpdate() throws RemoteException, OperationApplicationException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        queue.enqueue(
+                new Seq<>(
+                        new Put<>(taskList, new NameData("list1")),
+                        new Put<>(task, new TitleData("task1"))));
+        queue.flush();
+
+        assertThat(new Seq<>(
+                        new Put<>(task, new TitleData("task1b"))),
+                notifies(
+                        TaskContract.getContentUri(mAuthority),
+                        queue,
+                        // taskprovider should notity the tasks URI iself, the task diretory and the instances directory
+                        containsInAnyOrder(
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(is("/tasks"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(startsWith("/tasks/"))
+                                ),
+                                allOf(
+                                        scheme("content"),
+                                        authority(mAuthority),
+                                        path(is("/instances"))
+                                ))));
+    }
+
+
+    /**
+     * Test that an update that doesn't change anything doesn't trigger a notification.
+     */
+    @Test
+    public void testNoOpUpdate() throws RemoteException, OperationApplicationException
+    {
+        RowSnapshot<TaskLists> taskList = new VirtualRowSnapshot<>(new LocalTaskListsTable(mAuthority));
+        RowSnapshot<Tasks> task = new VirtualRowSnapshot<>(new TaskListScoped(taskList, new TasksTable(mAuthority)));
+        OperationsQueue queue = new BasicOperationsQueue(mClient);
+
+        queue.enqueue(
+                new Seq<>(
+                        new Put<>(taskList, new NameData("list1")),
+                        new Put<>(task, new TitleData("task1"))));
+        queue.flush();
+
+        assertThat(new Seq<>(
+                        new Put<>(task, new TitleData("task1"))),
+                notifies(
+                        TaskContract.getContentUri(mAuthority),
+                        queue,
+                        // there should no notification
+                        emptyIterable()));
+    }
+
+}

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/matchers/NotifiesMatcher.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/matchers/NotifiesMatcher.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.matchers;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.HandlerThread;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.OperationsQueue;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class NotifiesMatcher extends TypeSafeDiagnosingMatcher<Iterable<? extends Operation<?>>>
+{
+    private final Uri mUri;
+    private final OperationsQueue mOperationsQueue;
+    private final Matcher<Iterable<? extends Uri>> mDelegate;
+
+
+    public static Matcher<Iterable<? extends Operation<?>>> notifies(@NonNull Uri uri, @NonNull OperationsQueue operationsQueue, @NonNull Matcher<Iterable<? extends Uri>> delegate)
+    {
+        return new NotifiesMatcher(uri, operationsQueue, delegate);
+    }
+
+
+    public NotifiesMatcher(Uri uri, @NonNull OperationsQueue operationsQueue, @NonNull Matcher<Iterable<? extends Uri>> delegate)
+    {
+        mUri = uri;
+        mOperationsQueue = operationsQueue;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Iterable<? extends Operation<?>> item, Description mismatchDescription)
+    {
+        Collection<Uri> notifications = Collections.synchronizedCollection(new HashSet<>());
+        HandlerThread handlerThread = new HandlerThread("ObserverHandlerThread");
+        handlerThread.start();
+
+        ContentObserver observer = new ContentObserver(new Handler(handlerThread.getLooper()))
+        {
+            @Override
+            public void onChange(boolean selfChange, Uri uri)
+            {
+                super.onChange(selfChange, uri);
+                System.out.println("Notifcation: " + uri);
+                notifications.add(uri);
+            }
+        };
+
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        context.getContentResolver().registerContentObserver(mUri, true, observer);
+        try
+        {
+            try
+            {
+                mOperationsQueue.enqueue(item);
+                mOperationsQueue.flush();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Exception during executing the target OperationBatch", e);
+            }
+
+            Thread.sleep(100);
+            if (!mDelegate.matches(notifications))
+            {
+                mismatchDescription.appendText("Wrong notifications ");
+                mDelegate.describeMismatch(notifications, mismatchDescription);
+                return false;
+            }
+            return true;
+        }
+        catch (InterruptedException e)
+        {
+            e.printStackTrace();
+            return false;
+        }
+        finally
+        {
+            context.getContentResolver().unregisterContentObserver(observer);
+            handlerThread.quit();
+        }
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("Notifies ").appendDescriptionOf(mDelegate);
+    }
+}

--- a/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/matchers/UriMatcher.java
+++ b/opentasks-provider/src/androidTest/java/org/dmfs/provider/tasks/matchers/UriMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.matchers;
+
+import android.net.Uri;
+
+import org.hamcrest.Matcher;
+
+import static org.dmfs.jems.hamcrest.matchers.LambdaMatcher.having;
+import static org.hamcrest.Matchers.is;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class UriMatcher
+{
+    public static Matcher<Uri> scheme(String scheme)
+    {
+        return having(Uri::getScheme, is(scheme));
+    }
+
+
+    public static Matcher<Uri> authority(String authority)
+    {
+        return having(Uri::getEncodedAuthority, is(authority));
+    }
+
+
+    public static Matcher<Uri> path(Matcher<String> patchMatcher)
+    {
+        return having(Uri::getEncodedPath, patchMatcher);
+    }
+
+}

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesInstanceAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesInstanceAdapter.java
@@ -28,6 +28,7 @@ import org.dmfs.jems.single.elementary.Collected;
 import org.dmfs.jems.single.elementary.Reduced;
 import org.dmfs.provider.tasks.TaskDatabaseHelper;
 import org.dmfs.provider.tasks.model.adapters.FieldAdapter;
+import org.dmfs.provider.tasks.utils.ContainsValues;
 import org.dmfs.tasks.contract.TaskContract;
 
 import java.util.ArrayList;
@@ -111,7 +112,7 @@ public class CursorContentValuesInstanceAdapter extends AbstractInstanceAdapter
     @Override
     public boolean hasUpdates()
     {
-        return mValues != null && mValues.size() > 0;
+        return mValues != null && mValues.size() > 0 && !new ContainsValues(mValues).satisfiedBy(mCursor);
     }
 
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesListAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesListAdapter.java
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.dmfs.provider.tasks.TaskDatabaseHelper;
 import org.dmfs.provider.tasks.model.adapters.FieldAdapter;
+import org.dmfs.provider.tasks.utils.ContainsValues;
 import org.dmfs.tasks.contract.TaskContract;
 
 
@@ -81,7 +82,7 @@ public class CursorContentValuesListAdapter extends AbstractListAdapter
     @Override
     public boolean hasUpdates()
     {
-        return mValues != null && mValues.size() > 0;
+        return mValues != null && mValues.size() > 0 && !new ContainsValues(mValues).satisfiedBy(mCursor);
     }
 
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesTaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/CursorContentValuesTaskAdapter.java
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.dmfs.provider.tasks.TaskDatabaseHelper;
 import org.dmfs.provider.tasks.model.adapters.FieldAdapter;
+import org.dmfs.provider.tasks.utils.ContainsValues;
 import org.dmfs.tasks.contract.TaskContract;
 
 
@@ -103,7 +104,7 @@ public class CursorContentValuesTaskAdapter extends AbstractTaskAdapter
     @Override
     public boolean hasUpdates()
     {
-        return mValues != null && mValues.size() > 0;
+        return mValues != null && mValues.size() > 0 && !new ContainsValues(mValues).satisfiedBy(mCursor);
     }
 
 

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ContainsValues.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/ContainsValues.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import org.dmfs.jems.predicate.Predicate;
+
+import java.util.Arrays;
+
+
+/**
+ * A {@link Predicate} which determines whether all values of a ContentValues object are present in a {@link Cursor}.
+ *
+ * @author Marten Gajda
+ */
+public final class ContainsValues implements Predicate<Cursor>
+{
+    private final ContentValues mValues;
+
+
+    public ContainsValues(ContentValues values)
+    {
+        mValues = values;
+    }
+
+
+    @Override
+    public boolean satisfiedBy(Cursor testedInstance)
+    {
+        for (String key : mValues.keySet())
+        {
+            int columnIdx = testedInstance.getColumnIndex(key);
+            if (columnIdx < 0)
+            {
+                return false;
+            }
+
+            if (testedInstance.getType(columnIdx) == Cursor.FIELD_TYPE_BLOB)
+            {
+                if (!Arrays.equals(mValues.getAsByteArray(key), testedInstance.getBlob(columnIdx)))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                String stringValue = mValues.getAsString(key);
+                if (stringValue != null && !stringValue.equals(testedInstance.getString(columnIdx)) || stringValue == null && !testedInstance.isNull(columnIdx))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ContainsValuesTest.java
+++ b/opentasks-provider/src/test/java/org/dmfs/provider/tasks/utils/ContainsValuesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.provider.tasks.utils;
+
+import android.content.ContentValues;
+import android.database.MatrixCursor;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ContainsValuesTest
+{
+    @Test
+    public void test()
+    {
+        ContentValues values = new ContentValues();
+        values.put("a", 123);
+        values.put("b", "stringValue");
+        values.put("c", new byte[] { 3, 2, 1 });
+        values.putNull("d");
+
+        MatrixCursor cursor = new MatrixCursor(new String[] { "c", "b", "a", "d", "f" });
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValue", 123, null, "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValue", "123", null, "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2 }, "stringValue", 123, null, "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValueX", 123, null, "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValue", 1234, null, "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValue", 123, "123", "xyz"));
+        cursor.addRow(new Seq<>(321, "stringValueX", "1234", "123", "xyz"));
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1, 0 }, "stringValueX", 1234, "123", "xyz"));
+
+        cursor.moveToFirst();
+        assertThat(new ContainsValues(values), is(satisfiedBy(cursor)));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(satisfiedBy(cursor)));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+        cursor.moveToNext();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+    }
+
+
+    @Test
+    public void testMissingColumns()
+    {
+        ContentValues values = new ContentValues();
+        values.put("a", 123);
+        values.put("b", "stringValue");
+        values.put("c", new byte[] { 3, 2, 1 });
+        values.putNull("d");
+
+        MatrixCursor cursor = new MatrixCursor(new String[] { "c", "b" });
+        cursor.addRow(new Seq<>(new byte[] { 3, 2, 1 }, "stringValue"));
+
+        cursor.moveToFirst();
+        assertThat(new ContainsValues(values), is(not(satisfiedBy(cursor))));
+    }
+}

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tables/LocalTaskListsTable.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tables/LocalTaskListsTable.java
@@ -19,7 +19,6 @@ package org.dmfs.opentaskspal.tables;
 import android.accounts.Account;
 
 import org.dmfs.android.contentpal.Table;
-import org.dmfs.android.contentpal.tables.AccountScoped;
 import org.dmfs.android.contentpal.tables.DelegatingTable;
 import org.dmfs.android.contentpal.tables.Synced;
 import org.dmfs.tasks.contract.TaskContract;
@@ -42,9 +41,6 @@ public final class LocalTaskListsTable extends DelegatingTable<TaskContract.Task
 
     private LocalTaskListsTable(@NonNull Account localAccount, @NonNull String authority)
     {
-        // TODO When https://github.com/dmfs/opentasks/issues/416 is completed Synced can be removed from here:
-        super(new Synced<>(localAccount,
-                new AccountScoped<>(localAccount,
-                        new TaskListsTable(authority))));
+        super(new Synced<>(localAccount, new TaskListsTable(authority)));
     }
 }


### PR DESCRIPTION
Updates TaskProvider to skip updates which don't change any value. In such case no database operation is necessary and no notifications will be triggered.