### PR TITLE
Ignore recurrence if start and due are absent, fixes #841

### DIFF
--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractTaskAdapter.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/model/AbstractTaskAdapter.java
@@ -44,7 +44,8 @@ public abstract class AbstractTaskAdapter implements TaskAdapter
     @Override
     public boolean isRecurring()
     {
-        return valueOf(RRULE) != null || valueOf(RDATE).iterator().hasNext();
+        // recurring tasks must have an RRULE or RDATEs and at least one of DTSTART and DUE date
+        return (valueOf(RRULE) != null || valueOf(RDATE).iterator().hasNext()) && (valueOf(DTSTART) != null || valueOf(DUE) != null);
     }
 
 


### PR DESCRIPTION
Apparently there are tasks which have a recurrence rule but neither a dtstart nor a due date. This caused an NPE. By treating such tasks as non-recurring this should be fixed.