### PR TITLE
Let Due and Time data not set recurrence values. Fixes #858

### DIFF
--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/DueData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/DueData.java
@@ -17,12 +17,13 @@
 package org.dmfs.opentaskspal.tasks;
 
 import android.content.ContentProviderOperation;
-import androidx.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.tasks.contract.TaskContract;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -49,14 +50,8 @@ public final class DueData<T extends TaskContract.TaskColumns> implements RowDat
                 .withValue(TaskContract.Tasks.DUE, mDue.getTimestamp())
                 .withValue(TaskContract.Tasks.TZ, mDue.isAllDay() ? "UTC" : mDue.getTimeZone().getID())
                 .withValue(TaskContract.Tasks.IS_ALLDAY, mDue.isAllDay() ? 1 : 0)
-
                 .withValue(TaskContract.Tasks.DTSTART, null)
-
-                .withValue(TaskContract.Tasks.DURATION, null)
-
-                .withValue(TaskContract.Tasks.RDATE, null)
-                .withValue(TaskContract.Tasks.RRULE, null)
-                .withValue(TaskContract.Tasks.EXDATE, null);
+                .withValue(TaskContract.Tasks.DURATION, null);
     }
 
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/TimeData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/TimeData.java
@@ -17,7 +17,6 @@
 package org.dmfs.opentaskspal.tasks;
 
 import android.content.ContentProviderOperation;
-import androidx.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
@@ -27,6 +26,8 @@ import org.dmfs.jems.optional.elementary.Present;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 import org.dmfs.tasks.contract.TaskContract;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -95,13 +96,7 @@ public final class TimeData<T extends TaskContract.TaskColumns> implements RowDa
                 .withValue(TaskContract.Tasks.DTSTART, start.getTimestamp())
                 .withValue(TaskContract.Tasks.TZ, start.isAllDay() ? "UTC" : start.getTimeZone().getID())
                 .withValue(TaskContract.Tasks.IS_ALLDAY, start.isAllDay() ? 1 : 0)
-
                 .withValue(TaskContract.Tasks.DUE, due.isPresent() ? due.value().getTimestamp() : null)
-
-                .withValue(TaskContract.Tasks.DURATION, duration.isPresent() ? duration.value().toString() : null)
-
-                .withValue(TaskContract.Tasks.RDATE, null)
-                .withValue(TaskContract.Tasks.RRULE, null)
-                .withValue(TaskContract.Tasks.EXDATE, null);
+                .withValue(TaskContract.Tasks.DURATION, duration.isPresent() ? duration.value().toString() : null);
     }
 }

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/DueDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/DueDataTest.java
@@ -53,14 +53,8 @@ public final class DueDataTest
                                 containing(Tasks.DUE, due.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 withNullValue(Tasks.DTSTART),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 
@@ -76,14 +70,8 @@ public final class DueDataTest
                                 containing(Tasks.DUE, due.getTimestamp()),
                                 containing(Tasks.TZ, "GMT+04:00"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 withNullValue(Tasks.DTSTART),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 
@@ -99,14 +87,8 @@ public final class DueDataTest
                                 containing(Tasks.DUE, due.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 1),
-
                                 withNullValue(Tasks.DTSTART),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/TimeDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/TimeDataTest.java
@@ -58,14 +58,8 @@ public final class TimeDataTest
                                 containing(Tasks.DTSTART, start.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 containing(Tasks.DUE, due.getTimestamp()),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 
@@ -82,14 +76,8 @@ public final class TimeDataTest
                                 containing(Tasks.DTSTART, start.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 withNullValue(Tasks.DUE),
-
-                                containing(Tasks.DURATION, duration.toString()),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                containing(Tasks.DURATION, duration.toString())
                         )));
     }
 
@@ -105,14 +93,8 @@ public final class TimeDataTest
                                 containing(Tasks.DTSTART, start.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 withNullValue(Tasks.DUE),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 
@@ -147,14 +129,8 @@ public final class TimeDataTest
                                 containing(Tasks.DTSTART, startExpected.getTimestamp()),
                                 containing(Tasks.TZ, "GMT+06:00"),
                                 containing(Tasks.IS_ALLDAY, 0),
-
                                 containing(Tasks.DUE, due.getTimestamp()),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 
@@ -171,14 +147,8 @@ public final class TimeDataTest
                                 containing(Tasks.DTSTART, start.getTimestamp()),
                                 containing(Tasks.TZ, "UTC"),
                                 containing(Tasks.IS_ALLDAY, 1),
-
                                 containing(Tasks.DUE, due.getTimestamp()),
-
-                                withNullValue(Tasks.DURATION),
-
-                                withNullValue(Tasks.RDATE),
-                                withNullValue(Tasks.RRULE),
-                                withNullValue(Tasks.EXDATE)
+                                withNullValue(Tasks.DURATION)
                         )));
     }
 }


### PR DESCRIPTION
`DueData` and `TimeData` should not set recurrence values. That's not allowed on the instances table and, apparently, it's very unexpected and error prone.