### PR TITLE
 Always pass-non-null group cursor, fixes #758

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/TaskListFragment.java
@@ -29,14 +29,11 @@ import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.database.Cursor;
+import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.annotation.NonNull;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -49,6 +46,8 @@ import android.widget.ExpandableListView.OnChildClickListener;
 import android.widget.ExpandableListView.OnGroupCollapseListener;
 import android.widget.ListView;
 import android.widget.TextView;
+
+import com.google.android.material.snackbar.Snackbar;
 
 import org.dmfs.android.bolts.color.Color;
 import org.dmfs.android.bolts.color.elementary.ValueColor;
@@ -73,6 +72,10 @@ import org.dmfs.tasks.utils.OnModelLoadedListener;
 import org.dmfs.tasks.utils.RetainExpandableListView;
 import org.dmfs.tasks.utils.SafeFragmentUiRunnable;
 import org.dmfs.tasks.utils.SearchHistoryDatabaseHelper.SearchHistoryColumns;
+
+import androidx.annotation.NonNull;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
 
 
 /**
@@ -458,7 +461,7 @@ public class TaskListFragment extends SupportFragment
     @Override
     public void onLoaderReset(Loader<Cursor> loader)
     {
-        mAdapter.changeCursor(null);
+        mAdapter.changeCursor(new MatrixCursor(new String[] { "_id" }));
     }
 
 
@@ -512,7 +515,7 @@ public class TaskListFragment extends SupportFragment
      */
     public void prepareReload()
     {
-        mAdapter = new ExpandableGroupDescriptorAdapter(getActivity(), getLoaderManager(), mGroupDescriptor);
+        mAdapter = new ExpandableGroupDescriptorAdapter(new MatrixCursor(new String[] { "_id" }), getActivity(), getLoaderManager(), mGroupDescriptor);
         mExpandableListView.setAdapter(mAdapter);
         mExpandableListView.setOnChildClickListener(mTaskItemClickListener);
         mExpandableListView.setOnGroupCollapseListener(mTaskListCollapseListener);

--- a/opentasks/src/main/java/org/dmfs/tasks/utils/ExpandableGroupDescriptorAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/ExpandableGroupDescriptorAdapter.java
@@ -20,8 +20,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,6 +31,10 @@ import org.dmfs.tasks.groupings.filters.AbstractFilter;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
 
 
 /**
@@ -57,13 +59,7 @@ public class ExpandableGroupDescriptorAdapter extends CursorTreeAdapter implemen
     private Handler mHandler = new Handler();
 
 
-    public ExpandableGroupDescriptorAdapter(Context context, LoaderManager loaderManager, ExpandableGroupDescriptor descriptor)
-    {
-        this(null, context, loaderManager, descriptor);
-    }
-
-
-    public ExpandableGroupDescriptorAdapter(Cursor cursor, Context context, LoaderManager loaderManager, ExpandableGroupDescriptor descriptor)
+    public ExpandableGroupDescriptorAdapter(@NonNull Cursor cursor, @NonNull Context context, @NonNull LoaderManager loaderManager, @NonNull ExpandableGroupDescriptor descriptor)
     {
         super(cursor, context, false);
         mContext = context;
@@ -91,6 +87,7 @@ public class ExpandableGroupDescriptorAdapter extends CursorTreeAdapter implemen
     }
 
 
+    @NonNull
     @Override
     public Loader<Cursor> onCreateLoader(int pos, Bundle arguments)
     {


### PR DESCRIPTION
Under certain conditions the CursorTreeAdapter might have had a null Cursor. This commit attempts to fix this by passing an empty MatrixCursor instead. Hopefully this fixes #758 until we got rid of the CursorTreeAdapter.