### PR TITLE
Open first instance of newly created task, fixes #862

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 def jems_version = '1.24'
-def contentpal_version = '0.5'
+def contentpal_version = '0.6'
 def androidx_test_runner_version = '1.1.1'
 
 ext.deps = [

--- a/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/With.java
+++ b/opentasks-provider/src/main/java/org/dmfs/provider/tasks/utils/With.java
@@ -16,6 +16,8 @@
 
 package org.dmfs.provider.tasks.utils;
 
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.adapters.SinglePresent;
 import org.dmfs.jems.procedure.Procedure;
 import org.dmfs.jems.single.Single;
 
@@ -30,7 +32,7 @@ import org.dmfs.jems.single.Single;
 @Deprecated
 public final class With<T> implements Procedure<Procedure<T>>
 {
-    private final Single<T> mValue;
+    private final Optional<T> mValue;
 
 
     public With(T value)
@@ -41,6 +43,12 @@ public final class With<T> implements Procedure<Procedure<T>>
 
     public With(Single<T> value)
     {
+        this(new SinglePresent<>(value));
+    }
+
+
+    public With(Optional<T> value)
+    {
         mValue = value;
     }
 
@@ -48,6 +56,9 @@ public final class With<T> implements Procedure<Procedure<T>>
     @Override
     public void process(Procedure<T> delegate)
     {
-        delegate.process(mValue.value());
+        if (mValue.isPresent())
+        {
+            delegate.process(mValue.value());
+        }
     }
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/StaleListBroadcastReceiver.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/StaleListBroadcastReceiver.java
@@ -71,9 +71,9 @@ public final class StaleListBroadcastReceiver extends BroadcastReceiver
                                         new QueryRowSet<>(
                                                 new TaskListsView(authority, context.getContentResolver().acquireContentProviderClient(authority)),
                                                 new MultiProjection<>(TaskContract.TaskLists.ACCOUNT_NAME, TaskContract.TaskLists.ACCOUNT_TYPE),
-                                                new Not(new AnyOf(
+                                                new Not<>(new AnyOf<>(
                                                         new Joined<>(new Seq<>(
-                                                                new EqArg(TaskContract.TaskLists.ACCOUNT_TYPE, TaskContract.LOCAL_ACCOUNT_TYPE)),
+                                                                new EqArg<>(TaskContract.TaskLists.ACCOUNT_TYPE, TaskContract.LOCAL_ACCOUNT_TYPE)),
                                                                 new Mapped<>(AccountEq::new, new Seq<>(accountManager.getAccounts()))))))))))
         {
             context.startActivity(accountRequestIntent);

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/ActionService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/ActionService.java
@@ -124,7 +124,7 @@ public final class ActionService extends JobIntentService
                             TaskTitle.PROJECTION,
                             TaskVersion.PROJECTION,
                             TaskIsClosed.PROJECTION),
-                    new EqArg(TaskContract.Instances._ID, ContentUris.parseId(instanceUri))))
+                    new EqArg<>(TaskContract.Instances._ID, ContentUris.parseId(instanceUri))))
             {
                 resolveAction(intent.getAction()).execute(this, contentProviderClient, snapshot.values(), instanceUri);
             }

--- a/opentasks/src/main/java/org/dmfs/tasks/notification/TaskNotificationService.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/notification/TaskNotificationService.java
@@ -120,10 +120,10 @@ public class TaskNotificationService extends JobIntentService
                                                 new InstancesView<>(authority, getContentResolver().acquireContentProviderClient(authority))),
                                         new Composite<>(Id.PROJECTION, TaskVersion.PROJECTION, TaskPin.PROJECTION, TaskIsClosed.PROJECTION,
                                                 EffectiveDueDate.PROJECTION, TaskStart.PROJECTION),
-                                        new AnyOf(
+                                        new AnyOf<>(
                                                 // task is either pinned or has a notification
-                                                new EqArg(Tasks.PINNED, 1),
-                                                new In(Tasks._ID, new Mapped<>(p -> ContentUris.parseId(p.instance()), currentNotifications))))),
+                                                new EqArg<>(Tasks.PINNED, 1),
+                                                new In<>(Tasks._ID, new Mapped<>(p -> ContentUris.parseId(p.instance()), currentNotifications))))),
                         (o, o2) -> (int) (ContentUris.parseId(o.instance()) - ContentUris.parseId(o2.instance()))))
                 {
                     if (!diff.left().isPresent())

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/IsProperty.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/IsProperty.java
@@ -27,10 +27,10 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Gabor Keszthelyi
  */
-public final class IsProperty extends DelegatingPredicate
+public final class IsProperty extends DelegatingPredicate<TaskContract.Properties>
 {
     public IsProperty(String mimeType)
     {
-        super(new EqArg(TaskContract.PropertyColumns.MIMETYPE, mimeType));
+        super(new EqArg<>(TaskContract.PropertyColumns.MIMETYPE, mimeType));
     }
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/IsRelation.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/IsRelation.java
@@ -26,7 +26,7 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Gabor Keszthelyi
  */
-public final class IsRelation extends DelegatingPredicate
+public final class IsRelation extends DelegatingPredicate<TaskContract.Properties>
 {
     public IsRelation()
     {

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/TaskOnList.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/predicates/TaskOnList.java
@@ -29,11 +29,11 @@ import org.dmfs.tasks.contract.TaskContract;
  *
  * @author Gabor Keszthelyi
  */
-public final class TaskOnList extends DelegatingPredicate
+public final class TaskOnList extends DelegatingPredicate<TaskContract.Tasks>
 {
-    public TaskOnList(RowSnapshot<TaskContract.TaskLists> taskListRow, Predicate predicate)
+    public TaskOnList(RowSnapshot<TaskContract.TaskLists> taskListRow, Predicate<? super TaskContract.Tasks> predicate)
     {
-        super(new AllOf(predicate, new ReferringTo<>(TaskContract.Tasks.LIST_ID, taskListRow)));
+        super(new AllOf<>(predicate, new ReferringTo<>(TaskContract.Tasks.LIST_ID, taskListRow)));
     }
 
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/rowsets/Subtasks.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/rowsets/Subtasks.java
@@ -16,8 +16,6 @@
 
 package org.dmfs.opentaskspal.rowsets;
 
-import androidx.annotation.NonNull;
-
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowReference;
 import org.dmfs.android.contentpal.RowSet;
@@ -26,6 +24,8 @@ import org.dmfs.android.contentpal.predicates.ReferringTo;
 import org.dmfs.android.contentpal.rowsets.DelegatingRowSet;
 import org.dmfs.android.contentpal.rowsets.QueryRowSet;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -37,7 +37,7 @@ public final class Subtasks extends DelegatingRowSet<Tasks>
 {
 
     public Subtasks(@NonNull View<Tasks> view,
-                    @NonNull Projection projection,
+                    @NonNull Projection<? super Tasks> projection,
                     @NonNull RowReference<Tasks> parentTask)
     {
         super(new QueryRowSet<>(view, projection, new ReferringTo<>(Tasks.PARENT_ID, parentTask)));

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tables/TaskListScoped.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tables/TaskListScoped.java
@@ -17,7 +17,6 @@
 package org.dmfs.opentaskspal.tables;
 
 import android.content.ContentProviderClient;
-import androidx.annotation.NonNull;
 
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.Operation;
@@ -29,6 +28,8 @@ import org.dmfs.android.contentpal.View;
 import org.dmfs.opentaskspal.operations.TaskListTask;
 import org.dmfs.opentaskspal.predicates.TaskOnList;
 import org.dmfs.tasks.contract.TaskContract;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -61,7 +62,7 @@ public final class TaskListScoped implements Table<TaskContract.Tasks>
 
     @NonNull
     @Override
-    public Operation<TaskContract.Tasks> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<TaskContract.Tasks> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super TaskContract.Tasks> predicate)
     {
         return mDelegate.updateOperation(uriParams, new TaskOnList(mTaskListRow, predicate));
     }
@@ -69,7 +70,7 @@ public final class TaskListScoped implements Table<TaskContract.Tasks>
 
     @NonNull
     @Override
-    public Operation<TaskContract.Tasks> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<TaskContract.Tasks> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super TaskContract.Tasks> predicate)
     {
         return mDelegate.deleteOperation(uriParams, new TaskOnList(mTaskListRow, predicate));
     }
@@ -77,7 +78,7 @@ public final class TaskListScoped implements Table<TaskContract.Tasks>
 
     @NonNull
     @Override
-    public Operation<TaskContract.Tasks> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<TaskContract.Tasks> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super TaskContract.Tasks> predicate)
     {
         return mDelegate.assertOperation(uriParams, new TaskOnList(mTaskListRow, predicate));
     }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/views/TaskListScoped.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/views/TaskListScoped.java
@@ -54,7 +54,7 @@ public final class TaskListScoped implements View<TaskContract.Tasks>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super TaskContract.Tasks> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super TaskContract.Tasks> projection, @NonNull Predicate<? super TaskContract.Tasks> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(uriParams, projection, new TaskOnList(mTaskListRow, predicate), sorting);
     }


### PR DESCRIPTION
The Task Editor used to launch the details view for newly created tasks using the task Uri. In general this works, but it fails when the details view uses the Uri with the notification service (because that currently requires an instance Uri). So to fix this we load the first instance after creating a new task and use that one to show the details view.