### PR TITLE
Try workaround für #758

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/utils/ExpandableGroupDescriptorAdapter.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/utils/ExpandableGroupDescriptorAdapter.java
@@ -113,6 +113,22 @@ public class ExpandableGroupDescriptorAdapter extends CursorTreeAdapter implemen
 
 
     @Override
+    public View getGroupView(int groupPosition, boolean isExpanded, View convertView, ViewGroup parent)
+    {
+        try
+        {
+            return super.getGroupView(groupPosition, isExpanded, convertView, parent);
+        }
+        catch (IllegalStateException e)
+        {
+            // try to silence an issue which appears to be a race condition until we've gotten rid of ExpandableListView
+            // for now we just return an empty group view
+            return newGroupView(mContext, null /* we don't use this */, false, parent);
+        }
+    }
+
+
+    @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor cursor)
     {
         int pos = loader.getId();


### PR DESCRIPTION
Try to work around the crash caused by an IllegalStateException by always returning a valid group view. Some change in Android seems to cause this. We'll keep this workaround until we've removed the `ExpandableListView`for good.