### PR TITLE
Add OpenTasksPal classes to support SubTasks, #442

### DIFF
--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveDueDate.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/readdata/EffectiveDueDate.java
@@ -16,12 +16,9 @@
 
 package org.dmfs.opentaskspal.readdata;
 
-import androidx.annotation.NonNull;
-
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.android.contentpal.projections.Composite;
-import org.dmfs.android.contentpal.projections.Joined;
 import org.dmfs.android.contentpal.projections.MultiProjection;
 import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.jems.optional.Optional;
@@ -31,6 +28,8 @@ import org.dmfs.jems.optional.decorators.DelegatingOptional;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.tasks.contract.TaskContract;
 import org.dmfs.tasks.contract.TaskContract.Tasks;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -43,8 +42,7 @@ public final class EffectiveDueDate extends DelegatingOptional<DateTime>
 {
     public static final Projection<? super TaskContract.TaskColumns> PROJECTION = new Composite<>(
             new MultiProjection<>(Tasks.DUE, Tasks.DTSTART),
-            // TODO: figure out how to get rid of Joined here
-            new Joined<>(TaskDateTime.PROJECTION),
+            TaskDateTime.PROJECTION,
             TaskDuration.PROJECTION);
 
 

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/ColorData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/ColorData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2018 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,27 @@
  * limitations under the License.
  */
 
-package org.dmfs.opentaskspal.tables;
+package org.dmfs.opentaskspal.tasklists;
 
-import org.dmfs.android.contentpal.Table;
-import org.dmfs.android.contentpal.tables.BaseTable;
-import org.dmfs.android.contentpal.tables.DelegatingTable;
+import org.dmfs.android.bolts.color.Color;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
 import org.dmfs.tasks.contract.TaskContract;
 
 import androidx.annotation.NonNull;
 
 
 /**
- * {@link Table} for {@link TaskContract.Properties}.
+ * {@link RowData} of the color of a task list.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
-public final class PropertiesTable extends DelegatingTable<TaskContract.Properties>
+public final class ColorData extends DelegatingRowData<TaskContract.TaskLists>
 {
-    public PropertiesTable(@NonNull String authority)
+
+    public ColorData(@NonNull Color color)
     {
-        super(new BaseTable<>(TaskContract.Properties.getContentUri(authority)));
+        super((transactionContext, builder) -> builder.withValue(TaskContract.TaskLists.LIST_COLOR, color.argb()));
     }
+
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/OwnerData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/OwnerData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2018 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,28 @@
  * limitations under the License.
  */
 
-package org.dmfs.opentaskspal.tables;
+package org.dmfs.opentaskspal.tasklists;
 
-import org.dmfs.android.contentpal.Table;
-import org.dmfs.android.contentpal.tables.BaseTable;
-import org.dmfs.android.contentpal.tables.DelegatingTable;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
 import org.dmfs.tasks.contract.TaskContract;
 
 import androidx.annotation.NonNull;
 
 
 /**
- * {@link Table} for {@link TaskContract.Properties}.
+ * {@link RowData} of the owner account of a task list.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
-public final class PropertiesTable extends DelegatingTable<TaskContract.Properties>
+public final class OwnerData extends DelegatingRowData<TaskContract.TaskLists>
 {
-    public PropertiesTable(@NonNull String authority)
+
+    public OwnerData(@NonNull CharSequence owner)
     {
-        super(new BaseTable<>(TaskContract.Properties.getContentUri(authority)));
+        // TODO CharSequenceRowData allows null so this class wouldn't fail with that but erase the value
+        super(new CharSequenceRowData<>(TaskContract.TaskLists.OWNER, owner));
     }
+
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/SyncStatusData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/SyncStatusData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2018 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-package org.dmfs.opentaskspal.tables;
+package org.dmfs.opentaskspal.tasklists;
 
-import org.dmfs.android.contentpal.Table;
-import org.dmfs.android.contentpal.tables.BaseTable;
-import org.dmfs.android.contentpal.tables.DelegatingTable;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
 import org.dmfs.tasks.contract.TaskContract;
-
-import androidx.annotation.NonNull;
 
 
 /**
- * {@link Table} for {@link TaskContract.Properties}.
+ * {@link RowData} of the sync status of a task list.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
-public final class PropertiesTable extends DelegatingTable<TaskContract.Properties>
+public final class SyncStatusData extends DelegatingRowData<TaskContract.TaskLists>
 {
-    public PropertiesTable(@NonNull String authority)
+
+    public SyncStatusData()
     {
-        super(new BaseTable<>(TaskContract.Properties.getContentUri(authority)));
+        this(true);
     }
+
+
+    public SyncStatusData(boolean syncEnabled)
+    {
+        super((transactionContext, builder) -> builder.withValue(TaskContract.TaskLists.SYNC_ENABLED, syncEnabled ? 1 : 0));
+    }
+
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/VisibilityData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasklists/VisibilityData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2018 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-package org.dmfs.opentaskspal.tables;
+package org.dmfs.opentaskspal.tasklists;
 
-import org.dmfs.android.contentpal.Table;
-import org.dmfs.android.contentpal.tables.BaseTable;
-import org.dmfs.android.contentpal.tables.DelegatingTable;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
 import org.dmfs.tasks.contract.TaskContract;
-
-import androidx.annotation.NonNull;
 
 
 /**
- * {@link Table} for {@link TaskContract.Properties}.
+ * {@link RowData} of the visibility of a task list.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
-public final class PropertiesTable extends DelegatingTable<TaskContract.Properties>
+public final class VisibilityData extends DelegatingRowData<TaskContract.TaskLists>
 {
-    public PropertiesTable(@NonNull String authority)
+
+    public VisibilityData()
     {
-        super(new BaseTable<>(TaskContract.Properties.getContentUri(authority)));
+        this(true);
     }
+
+
+    public VisibilityData(boolean visible)
+    {
+        super((transactionContext, builder) -> builder.withValue(TaskContract.TaskLists.VISIBLE, visible ? 1 : 0));
+    }
+
 }

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/PropertyData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/PropertyData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasks;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.rowdata.Composite;
+import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
+import org.dmfs.tasks.contract.TaskContract;
+
+import androidx.annotation.NonNull;
+
+
+/**
+ * The {@link RowData} of a property row.
+ * <p>
+ * This just sets the {@link TaskContract.Properties#MIMETYPE} field of the row and leaves everything else to the provided {@link RowData}.
+ *
+ * @author Marten Gajda
+ */
+public final class PropertyData extends DelegatingRowData<TaskContract.Properties>
+{
+    public PropertyData(@NonNull String mimeType, @NonNull RowData<TaskContract.Properties> delegate)
+    {
+        super(new Composite<>(
+                new CharSequenceRowData<>(TaskContract.Properties.MIMETYPE, mimeType),
+                delegate
+        ));
+    }
+}

--- a/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/RelationData.java
+++ b/opentaskspal/src/main/java/org/dmfs/opentaskspal/tasks/RelationData.java
@@ -16,8 +16,6 @@
 
 package org.dmfs.opentaskspal.tasks;
 
-import androidx.annotation.NonNull;
-
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
@@ -26,6 +24,8 @@ import org.dmfs.android.contentpal.rowdata.DelegatingRowData;
 import org.dmfs.android.contentpal.rowdata.RawRowData;
 import org.dmfs.android.contentpal.rowdata.Referring;
 import org.dmfs.tasks.contract.TaskContract;
+
+import androidx.annotation.NonNull;
 
 
 /**
@@ -39,10 +39,11 @@ public final class RelationData extends DelegatingRowData<TaskContract.Propertie
                         int relType,
                         @NonNull RowSnapshot<TaskContract.Tasks> relatedTask)
     {
-        super(new Composite<>(
-                new Referring<TaskContract.Properties>(TaskContract.Property.Relation.TASK_ID, relatingTask),
-                new RawRowData<TaskContract.Properties>(TaskContract.Property.Relation.RELATED_TYPE, relType),
-                new Referring<TaskContract.Properties>(TaskContract.Property.Relation.RELATED_ID, relatedTask)));
+        super(new PropertyData(TaskContract.Property.Relation.CONTENT_ITEM_TYPE,
+                new Composite<>(
+                        new Referring<>(TaskContract.Property.Relation.TASK_ID, relatingTask),
+                        new RawRowData<>(TaskContract.Property.Relation.RELATED_TYPE, relType),
+                        new Referring<>(TaskContract.Property.Relation.RELATED_ID, relatedTask))));
     }
 
 
@@ -50,9 +51,10 @@ public final class RelationData extends DelegatingRowData<TaskContract.Propertie
                         int relType,
                         @NonNull CharSequence relatedTaskUid)
     {
-        super(new Composite<>(
-                new Referring<TaskContract.Properties>(TaskContract.Property.Relation.TASK_ID, relatingTask),
-                new RawRowData<TaskContract.Properties>(TaskContract.Property.Relation.RELATED_TYPE, relType),
-                new CharSequenceRowData<TaskContract.Properties>(TaskContract.Property.Relation.RELATED_UID, relatedTaskUid)));
+        super(new PropertyData(TaskContract.Property.Relation.CONTENT_ITEM_TYPE,
+                new Composite<>(
+                        new Referring<>(TaskContract.Property.Relation.TASK_ID, relatingTask),
+                        new RawRowData<>(TaskContract.Property.Relation.RELATED_TYPE, relType),
+                        new CharSequenceRowData<>(TaskContract.Property.Relation.RELATED_UID, relatedTaskUid))));
     }
 }

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/ColorDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/ColorDataTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasklists;
+
+import org.dmfs.android.bolts.color.elementary.ValueColor;
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Uinit test for {@link ColorData}
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ColorDataTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new ColorData(new ValueColor(0x12345678)),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.LIST_COLOR, 0x12345678))));
+    }
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/OwnerDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/OwnerDataTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasklists;
+
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link OwnerData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class OwnerDataTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new OwnerData("test"),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.OWNER, "test")
+                        )));
+    }
+
+    // TODO Test for null validation?
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/SyncStatusDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/SyncStatusDataTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasklists;
+
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Uinit test for {@link SyncStatusData}
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class SyncStatusDataTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new SyncStatusData(),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.SYNC_ENABLED, 1))));
+
+        assertThat(new SyncStatusData(true),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.SYNC_ENABLED, 1))));
+
+        assertThat(new SyncStatusData(false),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.SYNC_ENABLED, 0))));
+    }
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/VisibilityDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasklists/VisibilityDataTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasklists;
+
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Uinit test for {@link VisibilityData}
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class VisibilityDataTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new VisibilityData(),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.VISIBLE, 1))));
+
+        assertThat(new VisibilityData(true),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.VISIBLE, 1))));
+
+        assertThat(new VisibilityData(false),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.TaskLists.VISIBLE, 0))));
+    }
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/PropertyDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/PropertyDataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasks;
+
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link PropertyData}
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class PropertyDataTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new PropertyData("test", (context, builder) -> builder),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Properties.MIMETYPE, "test"))));
+
+        assertThat(new PropertyData("test", (context, builder) -> builder.withValue("key", "value")),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Properties.MIMETYPE, "test"),
+                                containing("key", "value"))));
+
+    }
+}

--- a/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/RelationDataTest.java
+++ b/opentaskspal/src/test/java/org/dmfs/opentaskspal/tasks/RelationDataTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.opentaskspal.tasks;
+
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.references.RowUriReference;
+import org.dmfs.tasks.contract.TaskContract;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link RelationData}
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class RelationDataTest
+{
+    @Test
+    public void test()
+    {
+        RowSnapshot<TaskContract.Tasks> child = failingMock(RowSnapshot.class);
+        RowSnapshot<TaskContract.Tasks> parent = failingMock(RowSnapshot.class);
+
+        doReturn(new RowUriReference<>(Uri.parse("content://tasks/123"))).when(parent).reference();
+        doReturn(new RowUriReference<>(Uri.parse("content://tasks/124"))).when(child).reference();
+
+        assertThat(new RelationData(parent, TaskContract.Property.Relation.RELTYPE_CHILD, child),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Property.Relation.MIMETYPE, TaskContract.Property.Relation.CONTENT_ITEM_TYPE),
+                                containing(TaskContract.Property.Relation.RELATED_TYPE, TaskContract.Property.Relation.RELTYPE_CHILD),
+                                containing(TaskContract.Property.Relation.TASK_ID, 123L),
+                                containing(TaskContract.Property.Relation.RELATED_ID, 124L))));
+
+        assertThat(new RelationData(parent, TaskContract.Property.Relation.RELTYPE_CHILD, "xyz"),
+                builds(
+                        withValuesOnly(
+                                containing(TaskContract.Property.Relation.MIMETYPE, TaskContract.Property.Relation.CONTENT_ITEM_TYPE),
+                                containing(TaskContract.Property.Relation.RELATED_TYPE, TaskContract.Property.Relation.RELTYPE_CHILD),
+                                containing(TaskContract.Property.Relation.TASK_ID, 123L),
+                                containing(TaskContract.Property.Relation.RELATED_UID, "xyz"))));
+    }
+}


### PR DESCRIPTION
This adds a few more RowData implementations to support the implementation of SubTasks.