### PR TITLE
fix android.util.AndroidRuntimeException: Calling startActivity() fro…

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/quicksettings/TaskQuickSettingsTile.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/quicksettings/TaskQuickSettingsTile.java
@@ -14,7 +14,7 @@ public class TaskQuickSettingsTile extends TileService {
     @Override
     public void onClick() {
         final Intent taskCreateIntent = new Intent(getApplicationContext(), EditTaskActivity.class);
-        taskCreateIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        taskCreateIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         unlockAndRun(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
…m outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?

Originally reported here https://gitlab.e.foundation/e/backlog/-/issues/1021

When you create a new Task via quick settings -> Create Tasks, it crashes:
```
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.dmfs.tasks, PID: 6623
    android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:912)
        at android.app.ContextImpl.startActivity(ContextImpl.java:888)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:379)
        at android.service.quicksettings.TileService.startActivityAndCollapse(TileService.java:308)
        at org.dmfs.tasks.quicksettings.TaskQuickSettingsTile$1.run(TaskQuickSettingsTile.java:21)
        at android.service.quicksettings.TileService$H.handleMessage(TileService.java:416)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6718)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```
This PR fixes it.