### PR TITLE
Fix progress gradient colors, fixes #1019

### DIFF
--- a/opentasks-theme/src/main/res/values/attrs.xml
+++ b/opentasks-theme/src/main/res/values/attrs.xml
@@ -19,4 +19,6 @@
 
     <attr name="opentasks_progress_gradient_end_color"
             format="color" />
+    <attr name="opentasks_progress_gradient_start_color"
+            format="color" />
 </resources>

--- a/opentasks-theme/src/main/res/values/theme_dark.xml
+++ b/opentasks-theme/src/main/res/values/theme_dark.xml
@@ -36,6 +36,7 @@
         <item name="tabIconTint">?attr/colorPrimary</item>
         <item name="tabIndicatorColor">?attr/colorPrimary</item>
 
+        <item name="opentasks_progress_gradient_start_color">#00000000</item>
         <item name="opentasks_progress_gradient_end_color">@color/white_6_percent</item>
 
         <item name="android:scrollbarTrackVertical">@null</item>
@@ -67,6 +68,7 @@
         <item name="tabIconTint">?attr/colorPrimary</item>
         <item name="tabIndicatorColor">?attr/colorPrimary</item>
 
+        <item name="opentasks_progress_gradient_start_color">#00000000</item>
         <item name="opentasks_progress_gradient_end_color">@color/white_6_percent</item>
 
         <item name="android:scrollbarTrackVertical">@null</item>

--- a/opentasks-theme/src/main/res/values/theme_light.xml
+++ b/opentasks-theme/src/main/res/values/theme_light.xml
@@ -39,6 +39,7 @@
         <item name="tabIconTint">?attr/colorPrimary</item>
         <item name="tabIndicatorColor">?attr/colorPrimary</item>
 
+        <item name="opentasks_progress_gradient_start_color">#00000000</item>
         <item name="opentasks_progress_gradient_end_color">@color/black_3_percent</item>
 
         <item name="android:scrollbarTrackVertical">@null</item>
@@ -73,6 +74,7 @@
         <item name="tabIconTint">?attr/colorPrimary</item>
         <item name="tabIndicatorColor">?attr/colorPrimary</item>
 
+        <item name="opentasks_progress_gradient_start_color">#00000000</item>
         <item name="opentasks_progress_gradient_end_color">@color/black_3_percent</item>
 
         <item name="android:scrollbarTrackVertical">@null</item>

--- a/opentasks/src/main/res/drawable/task_progress_background_shade.xml
+++ b/opentasks/src/main/res/drawable/task_progress_background_shade.xml
@@ -5,8 +5,8 @@
         <shape android:shape="rectangle">
             <gradient
                     android:angle="180"
-                    android:centerColor="#00000000"
-                    android:endColor="#00000000"
+                    android:centerColor="?attr/opentasks_progress_gradient_start_color"
+                    android:endColor="?attr/opentasks_progress_gradient_start_color"
                     android:startColor="?attr/opentasks_progress_gradient_end_color" />
         </shape>
     </item>


### PR DESCRIPTION
Before Android 10, colors in drawables must either all use attr
references or colors, not a mix of both, see https://stackoverflow.com/questions/35363335/gradient-crashes-with-illegalargumentexception-on-android-m