### PR TITLE
Hierarchical checklists

### DIFF
--- a/opentasks/src/main/java/org/dmfs/tasks/model/DescriptionItem.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/model/DescriptionItem.java
@@ -27,13 +27,15 @@ public final class DescriptionItem
     public boolean checkbox;
     public boolean checked;
     public String text;
+    public int level;
 
 
-    public DescriptionItem(boolean checkbox, boolean checked, String text)
+    public DescriptionItem(boolean checkbox, boolean checked, String text, int level)
     {
         this.checkbox = checkbox;
         this.checked = checked;
         this.text = text;
+        this.level = level;
     }
 
 
@@ -43,13 +45,14 @@ public final class DescriptionItem
         return obj instanceof DescriptionItem
                 && ((DescriptionItem) obj).checkbox == checkbox
                 && ((DescriptionItem) obj).checked == checked
-                && ((DescriptionItem) obj).text.equals(text);
+                && ((DescriptionItem) obj).text.equals(text)
+                && ((DescriptionItem) obj).level == level;
     }
 
 
     @Override
     public int hashCode()
     {
-        return text.hashCode() * 31 + (checkbox ? 1 : 0) + (checked ? 2 : 0);
+        return text.hashCode() * 31 + (checkbox ? 1 : 0) + (checked ? 2 : 0) + level * 17;
     }
 }

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/DescriptionFieldView.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/DescriptionFieldView.java
@@ -62,6 +62,7 @@ import org.dmfs.tasks.utils.DescriptionMovementMethod;
 
 import java.util.List;
 
+import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.view.ViewCompat;
 
 import static org.dmfs.jems.optional.elementary.Absent.absent;
@@ -250,6 +251,20 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
 
     private void bindItemView(final View itemView, final DescriptionItem item)
     {
+        // set the left indend button listener
+        AppCompatImageView indend_left = itemView.findViewById(R.id.indend_left);
+        indend_left.setOnClickListener((view -> {
+            if (item.level > 0) {
+                item.level -= 1;
+                bindItemView(itemView, item);
+            }
+        }));
+        AppCompatImageView indend_right = itemView.findViewById(R.id.indend_right);
+        indend_right.setOnClickListener((view -> {
+            item.level += 1;
+            bindItemView(itemView, item);
+        }));
+
         // set the checkbox status
         CheckBox checkbox = itemView.findViewById(android.R.id.checkbox);
 

--- a/opentasks/src/main/java/org/dmfs/tasks/widget/DescriptionFieldView.java
+++ b/opentasks/src/main/java/org/dmfs/tasks/widget/DescriptionFieldView.java
@@ -194,6 +194,7 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
             if (itemView == null || itemView.getId() != R.id.checklist_element)
             {
                 itemView = createItemView();
+
                 mContainer.addDragView(itemView, itemView.findViewById(R.id.drag_handle), mContainer.getChildCount() - 1);
             }
 
@@ -251,6 +252,11 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
     {
         // set the checkbox status
         CheckBox checkbox = itemView.findViewById(android.R.id.checkbox);
+
+        // set the left margin for hierarchical lists
+        MarginLayoutParams lp = (MarginLayoutParams) checkbox.getLayoutParams();
+        lp.leftMargin = checkbox.getPaddingLeft() * 10 * item.level;
+        checkbox.setLayoutParams(lp);
 
         // make sure we don't receive our own updates
         checkbox.setOnCheckedChangeListener(null);
@@ -463,7 +469,7 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
         mContainer.clearFocus();
 
         // create a new empty item
-        DescriptionItem item = new DescriptionItem(withCheckBox, false, initialText);
+        DescriptionItem item = new DescriptionItem(withCheckBox, false, initialText, 0);
         mCurrentValue.add(pos, item);
         View newItem = createItemView();
         bindItemView(newItem, item);
@@ -529,7 +535,7 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
 
                 if (lines.length == 1)
                 {
-                    DescriptionItem newItem = new DescriptionItem(true, item.checked, item.text);
+                    DescriptionItem newItem = new DescriptionItem(true, item.checked, item.text, 0);
                     mCurrentValue.add(idx, newItem);
                     new Animated(mContainer.getChildAt(origidx), v -> (ViewGroup) v).process(v -> bindItemView(v, newItem));
                     setupActionView(newItem);
@@ -538,7 +544,7 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
                 {
                     for (String i : lines)
                     {
-                        DescriptionItem newItem = new DescriptionItem(true, false, i);
+                        DescriptionItem newItem = new DescriptionItem(true, false, i, 0);
                         mCurrentValue.add(idx, newItem);
                         if (idx == origidx)
                         {
@@ -557,7 +563,7 @@ public class DescriptionFieldView extends AbstractFieldView implements OnChecked
             }
             else
             {
-                DescriptionItem newItem = new DescriptionItem(false, item.checked, item.text);
+                DescriptionItem newItem = new DescriptionItem(false, item.checked, item.text, item.level);
                 mCurrentValue.add(idx, newItem);
                 if (idx == 0 || mCurrentValue.get(idx - 1).checkbox)
                 {

--- a/opentasks/src/main/res/drawable/ic_left_arrow.xml
+++ b/opentasks/src/main/res/drawable/ic_left_arrow.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="558.957"
+    android:viewportWidth="558.957" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M462.745,0l-366.533,279.479l366.533,279.478l0,-139.736l-184.032,-139.742l184.032,-139.741z"/>
+</vector>

--- a/opentasks/src/main/res/drawable/ic_right_arrow.xml
+++ b/opentasks/src/main/res/drawable/ic_right_arrow.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="558.957"
+    android:viewportWidth="558.957" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M462.745,279.479l-366.533,279.478l-0,-139.736l184.032,-139.742l-184.032,-139.741l-0,-139.738z"/>
+</vector>

--- a/opentasks/src/main/res/layout/description_field_view_element.xml
+++ b/opentasks/src/main/res/layout/description_field_view_element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/checklist_element"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -7,32 +7,22 @@
         android:layout_marginLeft="-4dp"
         android:clipToPadding="false"
         android:clipChildren="false"
-        android:animateLayoutChanges="true">
+        android:animateLayoutChanges="true"
+        android:orientation="horizontal">
 
 
     <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@android:id/checkbox"
-            android:layout_width="wrap_content"
+            android:layout_width="40dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
             android:background="@android:color/transparent"
-            android:padding="4dp" />
-
-    <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/drag_handle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:padding="4dp"
-            android:src="@drawable/ic_drag_indicator_24px" />
+            android:padding="4dp"/>
 
     <androidx.appcompat.widget.AppCompatEditText
             android:id="@android:id/title"
             android:layout_width="0dp"
+            android:layout_weight="0.7"
             android:layout_height="wrap_content"
-            android:layout_alignWithParentIfMissing="true"
-            android:layout_toStartOf="@id/drag_handle"
-            android:layout_toEndOf="@android:id/checkbox"
             android:focusable="true"
             android:focusableInTouchMode="true"
             android:hint="@string/opentasks_checklist_empty_item_hint"
@@ -42,13 +32,26 @@
             android:paddingBottom="8dp"
             android:scrollHorizontally="false"
             android:singleLine="false"
-            android:textSize="16sp" />
+            android:textSize="16sp"/>
 
-    <FrameLayout
-            android:id="@+id/action_bar"
-            android:layout_width="match_parent"
+    <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/indend_left"
+            android:layout_width="40dp"
             android:layout_height="wrap_content"
-            android:layout_below="@android:id/title"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentEnd="true" />
-</RelativeLayout>
+            android:padding="4dp"
+            android:src="@drawable/ic_left_arrow"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/indend_right"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_right_arrow"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/drag_handle"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_drag_indicator_24px"/>
+</LinearLayout>


### PR DESCRIPTION
This draft adds the ability to display and adjust hierarchical tasks, i.e.
```
- [ ] test1
  - [ ] test11
    - [ ] test111
  - [ ] test12
- [ ] test2
  - [ ] test21
    - [ ] test211
  - [ ] test22
- [ ] test3
  - [ ] test31
    - [ ] test311
  - [ ] test32
```
will be displayed as:
![image](https://user-images.githubusercontent.com/8593000/160131455-81f197fa-0fc8-44e0-9b15-1c09de403645.png)
The left and right buttons are used to indend the item to the left or right.
This is done rather hackish, as I am rather unfamiliar with Android Layouting.
Maybe a swiping motion of the item would be better for choosing the level.